### PR TITLE
Fix /friend inconsistencies

### DIFF
--- a/GameServer/commands/playercommands/friend.cs
+++ b/GameServer/commands/playercommands/friend.cs
@@ -16,8 +16,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *
  */
+using System;
 using System.Linq;
-
 using DOL.GS.Friends;
 
 namespace DOL.GS.Commands
@@ -44,57 +44,89 @@ namespace DOL.GS.Commands
 			
 			string name = string.Join(" ", args, 1, args.Length - 1);
 
-			int result = 0;
-			GameClient fclient = WorldMgr.GuessClientByPlayerNameAndRealm(name, 0, false, out result);
-			if (fclient != null && !GameServer.ServerRules.IsSameRealm(fclient.Player, client.Player, true))
-			{
-				fclient = null;
-			}
+			// attempt to remove from friends list now to avoid being unable to do so because of a guessed name from an online player
+			if (RemoveFriend(name, client))
+				return;
 
-			if (fclient == null)
+			int result;
+			GameClient fclient = WorldMgr.GuessClientByPlayerNameAndRealm(name, 0, false, out result);
+
+			// abort if the returned player is from a hostile realm
+			if (fclient != null)
 			{
-				name = args[1];
-				if (client.Player.GetFriends().Contains(name) && client.Player.RemoveFriend(name))
-				{
-					DisplayMessage(client, name + " was removed from your friend list!");
-					return;
-				}
-				else
-				{
-					// nothing found
-					DisplayMessage(client, "No players online with that name.");
-					return;
-				}
+				name = fclient.Player.Name;
+
+				if (!GameServer.ServerRules.IsSameRealm(fclient.Player, client.Player, true))
+					result = 1;
 			}
 
 			switch (result)
 			{
-				case 2:
+				case 1: // not found
 					{
-						// name not unique
+						DisplayMessage(client, "No players with that name, or you cannot add this player.");
+						return;
+					}
+				case 2: // not unique
+					{
 						DisplayMessage(client, "Character name is not unique.");
-						break;
+						return;
 					}
 				case 3: // exact match
-				case 4: // guessed name
 					{
-						if (fclient == client)
+						if (IsAddingSelf(fclient, client))
+							return;
+
+						AddFriend(name, client);
+						return;
+					}
+				case 4: // guessed
+					{
+						if (IsAddingSelf(fclient, client))
+							return;
+
+						if (IsNameInFriendsList(name, client))
 						{
-							DisplayMessage(client, "You can't add yourself!");
+							DisplayMessage(client, "Type the full name to remove " + name + " from your list.");
 							return;
 						}
 
-						name = fclient.Player.Name;
-						if (client.Player.GetFriends().Contains(name) && client.Player.RemoveFriend(name))
-						{
-							DisplayMessage(client, name + " was removed from your friend list!");
-						}
-						else if (client.Player.AddFriend(name))
-						{
-							DisplayMessage(client, name + " was added to your friend list!");
-						}
-						break;
+						AddFriend(name, client);
+						return;
 					}
+			}
+		}
+
+		private bool IsAddingSelf(GameClient fclient, GameClient client)
+		{
+			if (fclient == client)
+			{
+				DisplayMessage(client, "You can't add yourself!");
+				return true;
+			}
+			return false;
+		}
+
+		private bool IsNameInFriendsList(string name, GameClient client, StringComparer comparer = null)
+		{
+			return client.Player.GetFriends().Contains(name, comparer);
+		}
+
+		private bool RemoveFriend(string name, GameClient client)
+		{
+			if (IsNameInFriendsList(name, client, StringComparer.OrdinalIgnoreCase) && client.Player.RemoveFriend(name))
+			{
+				DisplayMessage(client, name + " was removed from your friend list!");
+				return true;
+			}
+			return false;
+		}
+
+		private void AddFriend(string name, GameClient client)
+		{
+			if (client.Player.AddFriend(name))
+			{
+				DisplayMessage(client, name + " was added to your friend list!");
 			}
 		}
 	}

--- a/GameServer/managers/playermanager/FriendsManager.cs
+++ b/GameServer/managers/playermanager/FriendsManager.cs
@@ -211,7 +211,7 @@ namespace DOL.GS.Friends
 
 			var success = false;
 			if (!PlayersFriendsListsCache.TryUpdate(Player, list => {
-				var result = list.Except(new[] { Friend }).ToArray();
+				var result = list.Except(new[] { Friend }, StringComparer.OrdinalIgnoreCase).ToArray();
 				if (result.Length < list.Length)
 				{
 					success = true;


### PR DESCRIPTION
Currently the /friend commands has a few annoying issues:
- Unfriending someone is case sensitive when the target is offline, which is annoying due to players being able to use capital letters for their names, and inconsistent with how friending and unfriending someone work when the target is online. It also tells the player that no online player was found with that name, which is why I received a few reports that you can't remove offline players from the friends list.
- Trying to friend someone can result in the removal of another friend if that someone is offline.
- Trying to unfriend an offline player can result in the addition of another player. It also doesn't work if the name partially matches the one of the player from another realm.

This is fixed by first checking for friend removal, and allowing it only if their full name is used. Case insensitive. If no friend is removed, IsSameRealm() is called. If it returns false, we simply consider that no player was found, and we don't remove friends even if the name partially matches one in the list.

Then GuessClientByPlayerNameAndRealm()'s result is checked:
- If no online player was found (or if they're from another realm), we just leave.
- If there's a name collision (no exact match), we leave too.
- If there's an exact match (from a non-hostile realm), we add them as a friend (we already checked for friend removal).
- If there's a partial match but no name collision, we check against the friends list and prompt the player to use the full name if they wishes to remove them, otherwise we add them as a friend.