### PR TITLE
Fix Arrow Salvaging working backwards (#546)

### DIFF
--- a/GameServer/ECS-Components/RangeAttackComponent.cs
+++ b/GameServer/ECS-Components/RangeAttackComponent.cs
@@ -382,14 +382,10 @@ namespace DOL.GS
                 case eAttackResult.HitStyle:
                 case eAttackResult.Fumbled:
                     // remove an arrow and endurance
-                    InventoryItem ammo = RangeAttackAmmo;
-                    if (owner.GetModified(eProperty.ArrowRecovery) > 0 &&
-                        Util.Chance(100 - owner.GetModified(eProperty.ArrowRecovery)))
-                    {
-                        //do not remove an arrow
-                    }
-                    else
-                        owner.Inventory.RemoveCountFromStack(ammo, 1); //remove arrow
+                    int arrowRecoveryChance = owner.GetModified(eProperty.ArrowRecovery);
+
+                    if (arrowRecoveryChance == 0 || Util.Chance(100 - arrowRecoveryChance))
+                        owner.Inventory.RemoveCountFromStack(RangeAttackAmmo, 1);
 
                     if (RangedAttackType == eRangedAttackType.Critical)
                         owner.Endurance -= CRITICAL_SHOT_ENDURANCE;

--- a/GameServer/realmabilities_atlasOF/effects/AtlasOF_VolleyECSEffect.cs
+++ b/GameServer/realmabilities_atlasOF/effects/AtlasOF_VolleyECSEffect.cs
@@ -922,28 +922,13 @@ namespace DOL.GS.Effects
                 eDamageType damagetype = player.attackComponent.AttackDamageType(attackWeapon);
                 int speed = player.AttackSpeed(attackWeapon);
                 byte attackSpeed = (byte)(speed / 1000);
+
                 player.Out.SendMessage("Your shot arcs into the sky!", eChatType.CT_System, eChatLoc.CL_SystemWindow);
 
-                AtlasOF_ArrowSalvaging abArrowSalv = player.GetAbility<AtlasOF_ArrowSalvaging>();
-                Boolean remove = true;
-                if (abArrowSalv != null)
-                {
-                    int rnd;
-                    Random r = new Random();
-                    rnd = r.Next(0, 100);
-                    if ((rnd >= 0) && (rnd <= abArrowSalv.Amount))
-                    {
-                        remove = false;
-                    }
-                }
-                if (remove)
-                {
+                int arrowRecoveryChance = player.GetModified(eProperty.ArrowRecovery);
+                if (arrowRecoveryChance == 0 || Util.Chance(100 - arrowRecoveryChance))
                     player.Inventory.RemoveCountFromStack(ammo, 1);
-                }
-                else
-                {
-                    player.Out.SendMessage("Your ability " + abArrowSalv.Name + " save you an arrow", eChatType.CT_YouHit, eChatLoc.CL_SystemWindow);
-                }
+
                 player.Endurance -= VOLLEY_SHOT_ENDURANCE;
 
                 if (player.IsStealthed)


### PR DESCRIPTION
It gave 90, 80, 70, 60, 50% chance to keep the arrow, instead of 10, 20, 30, 40, 50%.
Also removed Arrow Salvaging showing a message when it's activated, since it doesn't do that on normal shots.