### PR TITLE
Fix Util.Chance(int) always returning true for 99%

### DIFF
--- a/GameServer/gameutils/Util.cs
+++ b/GameServer/gameutils/Util.cs
@@ -254,7 +254,7 @@ namespace DOL.GS
 		{
 			//return chancePercent >= Random(1, 100);
 			//return chancePercent >= soleInstance.RandomImpl(1, 100);
-			return chancePercent >= Util.CryptoNextInt(1, 100);
+			return chancePercent > CryptoNextInt(0, 100);
 		}
 
 		/// <summary>
@@ -266,7 +266,7 @@ namespace DOL.GS
 		{
 			//return chancePercent > RandomDouble();
 			//return chancePercent > soleInstance.RandomDoubleImpl();
-			return chancePercent > Util.CryptoNextDouble();
+			return chancePercent > CryptoNextDouble();
 		}
 
 		#endregion


### PR DESCRIPTION
Current behavior can be tested with this sample code (https://dotnetfiddle.net/3vbN99)

```
using System;
using System.Security.Cryptography;
					
public class Program
{
	public static RNGCryptoServiceProvider m_cryptoRandom;
	
	public static void Main()
	{
		m_cryptoRandom = new RNGCryptoServiceProvider();
		const int chance = 99;
		const int iteration = 1000000;
		int yup = 0;
		int nay = 0;
		
		for (int i = 0 ; i < iteration ; i++)
		{
			if (Chance(chance))
			{
				yup++;
			}
			else
			{
				nay++;
			}
		}
		
		Console.WriteLine($"{iteration} iteration with {chance}% chance.");
		Console.WriteLine($"- yup: {yup}");
		Console.WriteLine($"- nay: {nay}");
		Console.WriteLine($"- {(double) yup / iteration * 100}%");
	}
	public static bool Chance(int chancePercent)
	{
		return chancePercent >= CryptoNextInt(1, 100);
	}
	
	public static int CryptoNextInt(int minValue, int maxValue)
	{
		if (minValue == maxValue)
			return minValue;

		if (minValue > maxValue)
		{
			int swap = minValue;
			minValue = maxValue;
			maxValue = swap;
		}

		long diff = maxValue - minValue;
		byte[] buffer = new byte[4];

		// to prevent endless loop
		int counter = 0;

		while (true)
		{
			counter++;
			m_cryptoRandom.GetBytes(buffer);
			uint rand = BitConverter.ToUInt32(buffer, 0);
			long max = (1 + (long)int.MaxValue);

			long remainder = max % diff;

			// very low chance of getting an endless loop
			if (rand < max - remainder || counter > 10)
			{
				return (int)(minValue + (rand % diff));
			}
		}
	}
}
```