### PR TITLE
Fix Rapid Fire endurance cost to 5 and 3

### DIFF
--- a/GameServer/ECS-Components/RangeAttackComponent.cs
+++ b/GameServer/ECS-Components/RangeAttackComponent.cs
@@ -393,8 +393,8 @@ namespace DOL.GS
 
                     if (RangedAttackType == eRangedAttackType.Critical)
                         owner.Endurance -= CRITICAL_SHOT_ENDURANCE;
-                    else if (RangedAttackType == eRangedAttackType.RapidFire && owner.GetAbilityLevel(Abilities.RapidFire) == 1)
-                        owner.Endurance -= 2 * RANGE_ATTACK_ENDURANCE;
+                    else if (RangedAttackType == eRangedAttackType.RapidFire && owner.GetAbilityLevel(Abilities.RapidFire) == 2)
+                        owner.Endurance -= (int)Math.Ceiling(RANGE_ATTACK_ENDURANCE / 2.0);
                     else owner.Endurance -= RANGE_ATTACK_ENDURANCE;
                     break;
             }


### PR DESCRIPTION
A normal shot costs 5. Currently, RF1 costs 10 and RF2 costs 5.

According to https://camelotherald.fandom.com/wiki/Patch_Notes:_Version_1.62:
- Rapid Fire shots takes the same endurance as a normal bow shot, but do less damage.
- [...] The difference between the two is how much endurance they take - RF 2 takes less endurance than RF 1.

Not sure how much endurance RF2 is supposed to cost, so I did half of a normal shot then rounded up.