### PR TITLE
Fix door repair wood cost (#515)

### DIFF
--- a/DOLDatabase/Tables/Door.cs
+++ b/DOLDatabase/Tables/Door.cs
@@ -16,7 +16,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *
  */
-using System;
 using DOL.Database.Attributes;
 
 namespace DOL.Database
@@ -38,24 +37,11 @@ namespace DOL.Database
 		private byte m_realm;
 		private string m_guild;
 		private uint m_flags;
-		// private int m_constitution;
 		private int m_locked;
 		private int m_health;
-		private int m_maxHealth;
+		private int m_maxHealth; // Unused
 		private bool m_isPostern;
-		
-		/// <summary>
-		/// Create a door row
-		/// </summary>
-		public DBDoor()
-		{
-			m_zpos = 0;
-			m_ypos = 0;
-			m_xpos = 0;
-			m_heading = 0;
-			m_name = string.Empty;
-			m_internalID = 0;
-		}
+		private int m_state; // DOL.GS.eDoorState
 
 		/// <summary>
 		/// Name of door
@@ -187,20 +173,6 @@ namespace DOL.Database
 			}
 		}
 
-		/* 	[DataElement(AllowDbNull = false)]
-			public int Constitution
-			{
-				get
-				{
-					return m_constitution;
-				}
-				set
-				{
-					Dirty = true;
-					m_constitution = value;
-				}
-			}
-		 */
 		[DataElement(AllowDbNull = false)]
 		public byte Level
 		{
@@ -256,6 +228,7 @@ namespace DOL.Database
 				m_locked = value;
 			}
 		}
+
 		[DataElement(AllowDbNull = false)]
 		public int Health
 		{
@@ -269,6 +242,7 @@ namespace DOL.Database
 				m_health = value;
 			}
 		}
+
 		[DataElement(AllowDbNull = false)]
 		public int MaxHealth
 		{
@@ -284,7 +258,6 @@ namespace DOL.Database
 		}
 		
 		[DataElement(AllowDbNull = false)]
-
 		public bool IsPostern
 		{
 			get
@@ -295,6 +268,20 @@ namespace DOL.Database
 			{
 				Dirty = true;
 				m_isPostern = value;
+			}
+		}
+
+		[DataElement(AllowDbNull = false)]
+		public int State
+		{
+			get
+			{
+				return m_state;
+			}
+			set
+			{
+				Dirty = true;
+				m_state = value;
 			}
 		}
 	}

--- a/GameServer/GameServer.cs
+++ b/GameServer/GameServer.cs
@@ -1573,9 +1573,9 @@ namespace DOL.GS
 					//is tested for savability. A real waste of time, so it is commented out
 					//WorldMgr.SaveToDatabase();
 
+					DoorMgr.SaveKeepDoors();
 					GuildMgr.SaveAllGuilds();
 					BoatMgr.SaveAllBoats();
-
 					FactionMgr.SaveAllAggroToFaction();
 					craftingSaveCount = CraftingProgressMgr.Save();
 

--- a/GameServer/gameobjects/GameSiegeWeapon.cs
+++ b/GameServer/gameobjects/GameSiegeWeapon.cs
@@ -477,7 +477,7 @@ namespace DOL.GS
 			if (!repairCommand.PreFireChecks(Owner, this)) return;
 			repairCommand.StartRepair(Owner, this);
 		}
-		public bool Repair()
+		public bool Repair(int amount)
 		{
 			if (TimesRepaired <= 3)
 			{
@@ -486,8 +486,8 @@ namespace DOL.GS
 				// 	Owner.Out.SendMessage("You must have woodworking skill to repair a siege weapon.", eChatType.CT_Say, eChatLoc.CL_SystemWindow);
 				// 	return false;
 				// }
-				TimesRepaired = TimesRepaired + 1;
-				Health += (int)(this.MaxHealth * 0.15);
+				TimesRepaired += 1;
+				Health += amount;
 				return true;
 			}
 			else

--- a/GameServer/gameutils/DoorMgr.cs
+++ b/GameServer/gameutils/DoorMgr.cs
@@ -16,7 +16,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *
  */
-using System.Collections;
 using System.Collections.Generic;
 using System;
 using System.Reflection;
@@ -56,6 +55,31 @@ namespace DOL.GS
 				}
 			}
 			return true;
+		}
+
+		public static void SaveKeepDoors()
+		{
+			if (log.IsDebugEnabled)
+				log.Debug("Saving keep doors...");
+			try
+			{
+				lock (Lock)
+				{
+					foreach (List<IDoor> doorList in m_doors.Values)
+					{
+						foreach (IDoor door in doorList)
+						{
+							if (door is GameKeepDoor keepDoor && keepDoor.IsAttackableDoor)
+								keepDoor.SaveIntoDatabase();
+						}
+					}
+				}
+			}
+			catch (Exception e)
+			{
+				if (log.IsErrorEnabled)
+					log.Error("Error saving keep doors.", e);
+			}
 		}
 
 		public static bool LoadDoor(DBDoor door)

--- a/GameServer/keeps/Gameobjects/GameKeepDoor.cs
+++ b/GameServer/keeps/Gameobjects/GameKeepDoor.cs
@@ -38,9 +38,9 @@ namespace DOL.GS.Keeps
 
 		#region properties
 
-		protected int m_oldMaxHealth;
-
-		protected byte m_oldHealthPercent;
+		private int m_oldMaxHealth;
+		private byte m_oldHealthPercent;
+		private bool m_isPostern;
 		
 		private bool m_RelicMessage75 = false;
 		private bool m_RelicMessage50 = false;
@@ -187,30 +187,10 @@ namespace DOL.GS.Keeps
 					if (DoorIndex == 1)
 						return true;
 				}
-				else if (Component.Keep is GameKeep)
+				else if (Component.Keep is GameKeep or RelicGameKeep)
 				{
-					// if (Component.Skin == 10 || Component.Skin == 30) //old and new inner keep
-					// {
-					// 	if (DoorIndex == 1)
-					// 		return true;
-					// }
-					// if (Component.Skin == 0 || Component.Skin == 24)//old and new main gate
-					// {
-					// 	if (DoorIndex == 1 ||
-					// 		DoorIndex == 2)
-					// 		return true;
-					// }
-					
-					var door = DOLDB<DBDoor>.SelectObject(DB.Column("InternalID").IsEqualTo(m_doorID));
-					if (door == null) return false;
-					return !door.IsPostern;
-					
-				} 
-                else if (Component.Keep is RelicGameKeep)
-                {
-	                var door = DOLDB<DBDoor>.SelectObject(DB.Column("InternalID").IsEqualTo(m_doorID));
-	                return !door.IsPostern;
-                }
+					return !m_isPostern;
+				}
                 return false;
 			}
 		}
@@ -712,7 +692,8 @@ namespace DOL.GS.Keeps
 			m_level = 0;
 			m_model = 0xFFFF;
 			m_doorID = door.InternalID;
-			m_state = door.IsPostern || m_health > 0 ? eDoorState.Closed : eDoorState.Open; // State should be saved on the DB
+			m_isPostern = door.IsPostern;
+			m_state = m_isPostern || m_health > 0 ? eDoorState.Closed : eDoorState.Open; // State should be saved on the DB
 			this.AddToWorld();
 
 			foreach (AbstractArea area in this.CurrentAreas)
@@ -747,7 +728,7 @@ namespace DOL.GS.Keeps
 			m_name = "Keep Door";
 			m_oldHealthPercent = HealthPercent;
 			m_doorID = GenerateDoorID();
-			this.m_model = 0xFFFF;
+			m_model = 0xFFFF;
 			m_state = eDoorState.Closed;
 
 			if (AddToWorld())
@@ -759,11 +740,9 @@ namespace DOL.GS.Keeps
 			{
 				log.Error("Failed to load keep door from keepposition_id =" + pos.ObjectId + ". Component SkinID=" + component.Skin + ". KeepID=" + component.Keep.KeepID);
 			}
-
 		}
 
-		public void MoveToPosition(DBKeepPosition position)
-		{ }
+		public void MoveToPosition(DBKeepPosition position) { }
 
 		public int GenerateDoorID()
 		{
@@ -943,7 +922,6 @@ namespace DOL.GS.Keeps
 			return true;
 		}
 
-		public void NPCManipulateDoorRequest(GameNPC npc, bool open)
-		{ }
+		public void NPCManipulateDoorRequest(GameNPC npc, bool open) { }
 	}
 }


### PR DESCRIPTION
https://bug.atlasfreeshard.com/issues/515

The GetTotalWoodForLevel() method is supposed to return the amount of wood needed to repair one tick (5%), as shown in this doc: http://www.tradeskills.de/daoc/daten/guides/festungstorreparatur.pdf

Currently however, the returned value is multiplied by 5% and rounded down. Not only that, but the amount of consumed boards is also rounded down. Because of this, level 1 doors can be repaired with no wood in inventory, and a level 4 door can be repaired for free as long as there's at least one duskwood wooden board in inventory.

Level 1 door: 2 wood units per repair * 0.05 = 0.
Level 4 door: 840 wood units per repair * 0.05 = 42. Duskwood is worth 136. 42 / 136 = 0.

With this fix, the full value will be used and everything is rounded up, so repairing will always require and consume wood.

Costs are also much higher, a level 10 door will require 68100 * 20 wood units for a full repair, or 10020 duskwood wooden boards (about 21p913g). If this is too high, we probably should change the way GetTotalWoodForLevel() scales based on the door level instead of the value it returns.

Some forum post confirming the high cost: https://www.uthgard.net/forum/viewtopic.php?f=9&t=36722 (Sethor's post)

This change also applies to siege engine, but they're considered level 1 so it barely makes any difference.

On a side note, doors are automatically repaired when the server reboots, not sure if that's intended.