### PR TITLE
Fix Mastery of Stealth not requiring AugQui 2

### DIFF
--- a/GameServer/propertycalc/MaxSpeedCalculator.cs
+++ b/GameServer/propertycalc/MaxSpeedCalculator.cs
@@ -90,7 +90,7 @@ namespace DOL.GS.PropertyCalc
 				}
 				if (player.IsStealthed)
 				{
-					MasteryOfStealthAbility mos = player.GetAbility<MasteryOfStealthAbility>();
+					AtlasOF_MasteryOfStealth mos = player.GetAbility<AtlasOF_MasteryOfStealth>();
 					//GameSpellEffect bloodrage = SpellHandler.FindEffectOnTarget(player, "BloodRage");
 					//VanishEffect vanish = player.EffectList.GetOfType<VanishEffect>();
 
@@ -101,7 +101,7 @@ namespace DOL.GS.PropertyCalc
 					//if (vanish != null)
 						//speed *= vanish.SpeedBonus;
 					if (mos != null)
-						speed *= 1 + MasteryOfStealthAbility.GetSpeedBonusForLevel(mos.Level);
+						speed *= 1 + mos.GetAmountForLevel(mos.Level) / 100.0;
 					//if (bloodrage != null)
 						//speed *= 1 + (bloodrage.Spell.Value * 0.01); // 25 * 0.01 = 0.25 (a.k 25%) value should be 25.5
 					if (player.effectListComponent.ContainsEffectForEffectType(eEffect.ShadowRun)) //double stealthed movement with ShadowRun

--- a/GameServer/realmabilities/handlers/MasteryOfStealthAbility.cs
+++ b/GameServer/realmabilities/handlers/MasteryOfStealthAbility.cs
@@ -8,25 +8,20 @@ namespace DOL.GS.RealmAbilities
 	/// </summary>
 	public class MasteryOfStealthAbility : RAPropertyEnhancer
 	{
-		public MasteryOfStealthAbility(DBAbility dba, int level)
-			: base(dba, level, eProperty.Undefined)
-		{
-		}
-		public static double GetSpeedBonusForLevel(int level)
+		public MasteryOfStealthAbility(DBAbility dba, int level) : base(dba, level, eProperty.Undefined) { }
+
+		public override int GetAmountForLevel(int level)
 		{
 			return level switch
 			{
-				1 => 0.05,
-				2 => 0.10,
-				3 => 0.15,
+				1 => 5,
+				2 => 10,
+				3 => 15,
 				_ => 0
 			};
 		}
 
-		public override int MaxLevel
-		{
-			get { return 3; }
-		}
+		public override int MaxLevel => 3;
 
 		public override int CostForUpgrade(int level)
 		{
@@ -47,7 +42,7 @@ namespace DOL.GS.RealmAbilities
 				list.Add("");
 				for (int i = 1; i <= MaxLevel; i++)
 				{
-					list.Add("Level " + i + ": Amount: " + GetSpeedBonusForLevel(i) * 100 + "%");
+					list.Add("Level " + i + ": Amount: " + GetAmountForLevel(i) + "%");
 				}
 				return list;
 			}

--- a/GameServer/realmabilities_atlasOF/AtlasOF_RAHelpers.cs
+++ b/GameServer/realmabilities_atlasOF/AtlasOF_RAHelpers.cs
@@ -1,10 +1,10 @@
-using DOL.Database;
-
 namespace DOL.GS.RealmAbilities
 {
     public static class AtlasRAHelpers
     {
-        // 6 stat points per level (Augmented Str, Dex, etc).
+        /// <summary>
+        /// 6 stat points per level (Augmented Str, Dex, etc).
+        /// </summary>
         public static int GetStatEnhancerAmountForLevel(int level)
         {
             if (level < 1) return 0;
@@ -20,7 +20,9 @@ namespace DOL.GS.RealmAbilities
             }
         }
 
-        // 3% per level.
+        /// <summary>
+        /// 3% per level.
+        /// </summary>
         public static int GetPropertyEnhancer3AmountForLevel(int level)
         {
             if (level < 1) return 0;
@@ -36,7 +38,9 @@ namespace DOL.GS.RealmAbilities
             }
         }
 
-        // 5% per level.
+        /// <summary>
+        /// 5% per level.
+        /// </summary>
         public static int GetPropertyEnhancer5AmountForLevel(int level)
         {
             if (level < 1) return 0;
@@ -53,16 +57,32 @@ namespace DOL.GS.RealmAbilities
         }
 
         
-        // Shared by almost all passive OF Realm Abilities.
-        public static int GetCommonPassivesCostForUpgrade(int level)
+        /// <summary>
+        /// Shared by almost all passive OF Realm Abilities.
+        /// </summary>
+        public static int GetCommonUpgradeCostFor5LevelsRA(int currentLevel)
         {
-            switch (level)
+            switch (currentLevel)
             {
                 case 0: return 1;
                 case 1: return 3;
                 case 2: return 6;
                 case 3: return 10;
                 case 4: return 14;
+                default: return 1000;
+            }
+        }
+
+        /// <summary>
+        /// Shared by almost all active OF Realm Abilities (that have more than one level).
+        /// </summary>
+        public static int GetCommonUpgradeCostFor3LevelsRA(int currentLevel)
+        {
+            switch (currentLevel)
+            {
+                case 0: return 3;
+                case 1: return 6;
+                case 2: return 10;
                 default: return 1000;
             }
         }
@@ -129,6 +149,7 @@ namespace DOL.GS.RealmAbilities
 
             return player.CalculateSkillLevel(raFirstAid) >= level;
         }
+
         public static bool HasLongshotLevel(GamePlayer player, int level)
         {
             AtlasOF_Longshot raLongshot = player.GetAbility<AtlasOF_Longshot>();

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_ArmorOfFaith.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_ArmorOfFaith.cs
@@ -17,20 +17,8 @@ namespace DOL.GS.RealmAbilities
         public const int duration = 60000; // 60 seconds
         public override int MaxLevel { get { return 3; } }
         public override int GetReUseDelay(int level) { return 900; } // 15 mins
-        
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugConLevel(player, 3); }
-        
-        public override int CostForUpgrade(int level) {
-            switch (level+1)
-            {
-                case 1: return 3;
-                case 2: return 6;
-                case 3: return 10;
-                default: return 3;
-            }
-        }
-        
-         
+        public override int CostForUpgrade(int currentLevel) { return AtlasRAHelpers.GetCommonUpgradeCostFor3LevelsRA(currentLevel); } 
         public override void AddEffectsInfo(IList<string> list)
         {
             list.Add("Target: Self");

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_AvoidPain.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_AvoidPain.cs
@@ -17,19 +17,8 @@ namespace DOL.GS.RealmAbilities
         public const int duration = 60000; // 60 seconds
         public override int MaxLevel { get { return 3; } }
         public override int GetReUseDelay(int level) { return 900; } // 15 mins
-        
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugConLevel(player, 3); }
-        
-        public override int CostForUpgrade(int level) {
-            switch (level+1)//need to offset due to input levels being 0/1/2
-            {
-                case 1: return 3;
-                case 2: return 6;
-                case 3: return 10;
-                default: return 3;
-            }
-        }
-        
+        public override int CostForUpgrade(int currentLevel) { return AtlasRAHelpers.GetCommonUpgradeCostFor3LevelsRA(currentLevel); }
          
         public override void AddEffectsInfo(IList<string> list)
         {

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_AvoidanceOfMagicAbility.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_AvoidanceOfMagicAbility.cs
@@ -11,6 +11,6 @@ namespace DOL.GS.RealmAbilities
 	{
 		public AtlasOF_AvoidanceOfMagicAbility(DBAbility dba, int level) : base(dba, level) { }
 		public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
-		public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+		public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
 	}
 }

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_EtherealBondAbility.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_EtherealBondAbility.cs
@@ -25,7 +25,7 @@ namespace DOL.GS.RealmAbilities
 
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
         
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
 
         public override void Activate(GameLiving living, bool sendUpdates)
         {

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_FirstAid.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_FirstAid.cs
@@ -17,21 +17,7 @@ namespace DOL.GS.RealmAbilities
 		public AtlasOF_FirstAid(DBAbility dba, int level) : base(dba, level) { }
 
 		public override int MaxLevel { get { return 3; } }
-
-		public override int CostForUpgrade(int level)
-        {
-			switch (level+1)
-            {
-				case 1:
-					return 3;
-				case 2:
-					return 6;
-				case 3:
-					return 10;
-                default:	// default must return value for lvl 1
-					return 3;
-            }
-        }
+        public override int CostForUpgrade(int currentLevel) { return AtlasRAHelpers.GetCommonUpgradeCostFor3LevelsRA(currentLevel); }
 		
         /// <summary>
         /// Action

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_HailOfBlowsAbility.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_HailOfBlowsAbility.cs
@@ -18,16 +18,7 @@ namespace DOL.GS.RealmAbilities
         public override int MaxLevel { get { return 3; } }
         public override int GetReUseDelay(int level) { return 900; } // 15 mins
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugDexLevel(player, 3); }
-        
-        public override int CostForUpgrade(int level)
-        {
-            return level switch
-            {
-                1 => 6,
-                2 => 10,
-                _ => 3
-            };
-        }
+        public override int CostForUpgrade(int currentLevel) { return AtlasRAHelpers.GetCommonUpgradeCostFor3LevelsRA(currentLevel); }
         
         private DBSpell m_dbspell;
         private Spell m_spell = null;

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_LifterAbility.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_LifterAbility.cs
@@ -21,7 +21,7 @@ namespace DOL.GS.RealmAbilities
 		
 		protected override string ValueUnit { get {	return "%"; } }
 
-		public override int CostForUpgrade(int level) {	return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+		public override int CostForUpgrade(int level) {	return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
 
 		public override int GetAmountForLevel(int level)
 		{

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_LongWindAbility.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_LongWindAbility.cs
@@ -18,18 +18,7 @@ namespace DOL.GS.RealmAbilities
 
         protected override string ValueUnit { get { return "%"; } }
 
-        public override int CostForUpgrade(int level)
-        {
-            switch (level)
-				{
-					case 0: return 1;
-					case 1: return 3;
-					case 2: return 6;
-					case 3: return 10;
-					case 4: return 14;
-					default: return 14;
-				}
-        }
+        public override int CostForUpgrade(int currentLevel) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(currentLevel); }
 
         public override int GetAmountForLevel(int level)
         {

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_MajesticWill.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_MajesticWill.cs
@@ -13,15 +13,7 @@ namespace DOL.GS.RealmAbilities
         int m_duration = 60000; // 30s
 
         public override int MaxLevel { get { return 3; } }
-        public override int CostForUpgrade(int level) {
-            switch (level+1)
-            {
-                case 1: return 6;
-                case 2: return 10;
-                case 3: return 14;
-                default: return 6;
-            }
-        }
+        public override int CostForUpgrade(int currentLevel) { return AtlasRAHelpers.GetCommonUpgradeCostFor3LevelsRA(currentLevel); }
         public override int GetReUseDelay(int level) { return 1800; } // 30 mins
 
         public override void Execute(GameLiving living)

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_Masteries.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_Masteries.cs
@@ -12,7 +12,7 @@ namespace DOL.GS.RealmAbilities
 
         // MoP is 5% per level unlike most other Mastery RAs.
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer5AmountForLevel(level); } 
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -23,7 +23,7 @@ namespace DOL.GS.RealmAbilities
         public AtlasOF_MasteryOfParrying(DBAbility dba, int level) : base(dba, level) { }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugDexLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ namespace DOL.GS.RealmAbilities
         public AtlasOF_MasteryOfBlocking(DBAbility dba, int level) : base(dba, level) { }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugDexLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -45,7 +45,7 @@ namespace DOL.GS.RealmAbilities
         public AtlasOF_MasteryOfHealing(DBAbility dba, int level) : base(dba, level) { }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugAcuityLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -68,7 +68,7 @@ namespace DOL.GS.RealmAbilities
         }
 
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -80,7 +80,7 @@ namespace DOL.GS.RealmAbilities
         protected override string ValueUnit { get { return "%"; } }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugDexLevel(player, 3); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ namespace DOL.GS.RealmAbilities
         protected override string ValueUnit { get { return "%"; } }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugAcuityLevel(player, 3); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -104,7 +104,7 @@ namespace DOL.GS.RealmAbilities
         protected override string ValueUnit { get { return "%"; } }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugAcuityLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -116,7 +116,7 @@ namespace DOL.GS.RealmAbilities
         protected override string ValueUnit { get { return "%"; } }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugAcuityLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -127,7 +127,7 @@ namespace DOL.GS.RealmAbilities
         public AtlasOF_MasteryOfWater(DBAbility dba, int level) : base(dba, level, eProperty.WaterSpeed) { }
         protected override string ValueUnit { get { return "%"; } }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -139,7 +139,7 @@ namespace DOL.GS.RealmAbilities
         protected override string ValueUnit { get { return "%"; } }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugQuiLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -151,7 +151,7 @@ namespace DOL.GS.RealmAbilities
         protected override string ValueUnit { get { return "%"; } }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugQuiLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer5AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return base.CostForUpgrade(level); } // Placeholder
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor3LevelsRA(level); }
     }
     
     /// <summary>
@@ -163,7 +163,7 @@ namespace DOL.GS.RealmAbilities
         protected override string ValueUnit { get { return "%"; } }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugDexLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
     
     /// <summary>
@@ -175,6 +175,6 @@ namespace DOL.GS.RealmAbilities
         protected override string ValueUnit { get { return "%"; } }
         public override bool CheckRequirement(GamePlayer player) { return true; }
         public override int GetAmountForLevel(int level) { return level * 10; }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 }

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_Masteries.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_Masteries.cs
@@ -131,7 +131,7 @@ namespace DOL.GS.RealmAbilities
     }
 
     /// <summary>
-    /// Dodger.
+    /// Dodger ability
     /// </summary>
     public class AtlasOF_Dodger : RAPropertyEnhancer
     {
@@ -141,31 +141,40 @@ namespace DOL.GS.RealmAbilities
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
         public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
     }
+
+    /// <summary>
+    /// Mastery of Stealth ability
+    /// </summary>
+    public class AtlasOF_MasteryOfStealth : MasteryOfStealthAbility
+	{
+        public AtlasOF_MasteryOfStealth(DBAbility dba, int level) : base(dba, level) { }
+        protected override string ValueUnit { get { return "%"; } }
+        public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugQuiLevel(player, 2); }
+        public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer5AmountForLevel(level); }
+        public override int CostForUpgrade(int level) { return base.CostForUpgrade(level); } // Placeholder
+    }
     
+    /// <summary>
+    /// Dualist's Reflexes ability
+    /// </summary>
     public class AtlasOF_DualistsReflexes : RAPropertyEnhancer
     {
-        public AtlasOF_DualistsReflexes(DBAbility dba, int level) : base(dba, level, eProperty.OffhandDamageAndChance)
-        {
-            
-        }
+        public AtlasOF_DualistsReflexes(DBAbility dba, int level) : base(dba, level, eProperty.OffhandDamageAndChance) { }
         protected override string ValueUnit { get { return "%"; } }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugDexLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
         public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
-
     }
     
+    /// <summary>
+    /// Arrow Salvaging ability
+    /// </summary>
     public class AtlasOF_ArrowSalvaging : RAPropertyEnhancer
     {
-        public AtlasOF_ArrowSalvaging(DBAbility dba, int level) : base(dba, level, eProperty.ArrowRecovery)
-        {
-            
-        }
+        public AtlasOF_ArrowSalvaging(DBAbility dba, int level) : base(dba, level, eProperty.ArrowRecovery) { }
         protected override string ValueUnit { get { return "%"; } }
-
         public override bool CheckRequirement(GamePlayer player) { return true; }
         public override int GetAmountForLevel(int level) { return level * 10; }
         public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
-
     }
 }

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_MysticCrystalLoreAbility.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_MysticCrystalLoreAbility.cs
@@ -12,16 +12,7 @@ namespace DOL.GS.RealmAbilities
 	{
 		public AtlasOF_MysticCrystalLoreAbility(DBAbility dba, int level) : base(dba, level) { }
 
-        public override int CostForUpgrade(int level)
-        {
-			switch (level)
-            {
-                case 0: return 3;
-                case 1: return 6;
-                case 2: return 10;
-                default: return 1000;
-            }
-        }
+        public override int CostForUpgrade(int currentLevel) { return AtlasRAHelpers.GetCommonUpgradeCostFor3LevelsRA(currentLevel); }
         
         public override int GetReUseDelay(int level)
         {

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_RACritEnhancer.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_RACritEnhancer.cs
@@ -29,7 +29,7 @@ namespace DOL.GS.RealmAbilities
         public AtlasOF_WildPowerAbility(DBAbility dba, int level) : base(dba, level) { }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugAcuityLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer5AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ namespace DOL.GS.RealmAbilities
         public AtlasOF_WildHealingAbility(DBAbility dba, int level) : base(dba, level) { }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugAcuityLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer5AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -51,7 +51,7 @@ namespace DOL.GS.RealmAbilities
              public AtlasOF_WildArcanaAbility(DBAbility dba, int level) : base(dba, level, eProperty.CriticalDotHitChance) { }
              public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugAcuityLevel(player, 2); }
              public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer5AmountForLevel(level); }
-             public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+             public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
          }
 
     /// <summary>
@@ -62,7 +62,7 @@ namespace DOL.GS.RealmAbilities
         public AtlasOF_WildMinionAbility(DBAbility dba, int level) : base(dba, level, eProperty.Undefined) { }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugAcuityLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer5AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 
     /// <summary>
@@ -73,6 +73,6 @@ namespace DOL.GS.RealmAbilities
         public AtlasOF_FalconsEye(DBAbility dba, int level) : base(dba, level, eProperty.CriticalArcheryHitChance) { }
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugDexLevel(player, 2); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer5AmountForLevel(level); }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
     }
 }

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_RAStatEnhancer.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_RAStatEnhancer.cs
@@ -11,49 +11,49 @@ namespace DOL.GS.RealmAbilities
 	public class AtlasOF_RAStrengthEnhancer : RAStrengthEnhancer
 	{
 		public AtlasOF_RAStrengthEnhancer(DBAbility dba, int level) : base(dba, level) { }
-		public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+		public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetStatEnhancerAmountForLevel(level); }
     }
 
 	public class AtlasOF_RAConstitutionEnhancer : RAConstitutionEnhancer
 	{
 		public AtlasOF_RAConstitutionEnhancer(DBAbility dba, int level) : base(dba, level) { }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetStatEnhancerAmountForLevel(level); }
     }
 
 	public class AtlasOF_RAQuicknessEnhancer : RAQuicknessEnhancer
 	{
 		public AtlasOF_RAQuicknessEnhancer(DBAbility dba, int level) : base(dba, level) { }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetStatEnhancerAmountForLevel(level); }
     }
 
 	public class AtlasOF_RADexterityEnhancer : RADexterityEnhancer
 	{
 		public AtlasOF_RADexterityEnhancer(DBAbility dba, int level) : base(dba, level) { }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetStatEnhancerAmountForLevel(level); }
     }
 
 	public class AtlasOF_RAAcuityEnhancer : RAAcuityEnhancer
 	{
 		public AtlasOF_RAAcuityEnhancer(DBAbility dba, int level) : base(dba, level) { }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetStatEnhancerAmountForLevel(level); }
     }
 
 	public class AtlasOF_RAMaxManaEnhancer : RAMaxManaEnhancer
 	{
 		public AtlasOF_RAMaxManaEnhancer(DBAbility dba, int level) : base(dba, level) { }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
     }
 
 	public class AtlasOF_RAMaxHealthEnhancer : RAMaxHealthEnhancer
 	{
 		public AtlasOF_RAMaxHealthEnhancer(DBAbility dba, int level) : base(dba, level) { }
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
         public override bool CheckRequirement(GamePlayer player) { return true; } // Override NF level 40 requirement.
     }
@@ -69,7 +69,7 @@ namespace DOL.GS.RealmAbilities
 				return 1;
 			}
 		}
-		public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+		public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
 		public override int GetAmountForLevel(int level) { return 1; }
 		public override bool CheckRequirement(GamePlayer player) { return true; } // Override NF level 40 requirement.
 

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_RainOfBase.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_RainOfBase.cs
@@ -20,15 +20,7 @@ namespace DOL.GS.RealmAbilities
 
         public override int GetReUseDelay(int level) { return 900; } // 15 mins
 
-        public override int CostForUpgrade(int level) {
-            return level switch
-            {
-                0 => 3,
-                1 => 6,
-                2 => 10,
-                _ => 3,
-            };
-        }
+        public override int CostForUpgrade(int currentLevel) { return AtlasRAHelpers.GetCommonUpgradeCostFor3LevelsRA(currentLevel); }
 
         public override void AddEffectsInfo(IList<string> list)
         {

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_Regeneration.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_Regeneration.cs
@@ -16,7 +16,7 @@ namespace DOL.GS.RealmAbilities
 
         public AtlasOF_Regeneration(DBAbility dba, int level) : base(dba, level, eProperty.Undefined) { }
 
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
 
         public override int GetAmountForLevel(int level)
         {

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_SerenityAbility.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_SerenityAbility.cs
@@ -19,7 +19,7 @@ namespace DOL.GS.RealmAbilities
 
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugAcuityLevel(player, 2); }
 
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
 
         public override int GetAmountForLevel(int level)
         {

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_TheEmptyMindAbility.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_TheEmptyMindAbility.cs
@@ -17,17 +17,7 @@ namespace DOL.GS.RealmAbilities
         public override int MaxLevel { get { return 3; } }
         public override int GetReUseDelay(int level) { return 1800; } // 30 mins
         protected override int GetDuration() { return 60000; }
-
-        public override int CostForUpgrade(int level)
-		{
-			switch (level)
-			{
-				case 0: return 3;
-				case 1: return 6;
-				case 2: return 10;
-				default: return 1000;
-			}
-		}
+        public override int CostForUpgrade(int currentLevel) { return AtlasRAHelpers.GetCommonUpgradeCostFor3LevelsRA(currentLevel); }
 
         protected override int GetEffectiveness()
         {

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_ToughnessAbility.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_ToughnessAbility.cs
@@ -18,7 +18,7 @@ namespace DOL.GS.RealmAbilities
 
         public AtlasOF_ToughnessAbility(DBAbility dba, int level) : base(dba, level, eProperty.MaxHealth) { }
 
-        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+        public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
 
         public override int GetAmountForLevel(int level) { return AtlasRAHelpers.GetPropertyEnhancer3AmountForLevel(level); }
 

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_VeilRecovery.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_VeilRecovery.cs
@@ -27,6 +27,6 @@ namespace DOL.GS.RealmAbilities
             }
 		}
 		
-		public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonPassivesCostForUpgrade(level); }
+		public override int CostForUpgrade(int level) { return AtlasRAHelpers.GetCommonUpgradeCostFor5LevelsRA(level); }
 	}
 }

--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_WhirlingDervish.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_WhirlingDervish.cs
@@ -18,16 +18,7 @@ namespace DOL.GS.RealmAbilities
         public override int MaxLevel { get { return 3; } }
         public override int GetReUseDelay(int level) { return 900; } // 15 mins
         public override bool CheckRequirement(GamePlayer player) { return AtlasRAHelpers.HasAugDexLevel(player, 3); }
-        
-        public override int CostForUpgrade(int level) {
-            switch (level)
-            {
-                case 1: return 3;
-                case 2: return 6;
-                case 3: return 10;
-                default: return 3;
-            }
-        }
+        public override int CostForUpgrade(int currentLevel) { return AtlasRAHelpers.GetCommonUpgradeCostFor3LevelsRA(currentLevel); }
         
         private DBSpell m_dbspell;
         private Spell m_spell = null;


### PR DESCRIPTION
I decided to make a **AtlasOF_MasteryOfStealth** class for that, so the database has to be updated to use it:
```UPDATE `atlas`.`ability` SET `Implementation`='DOL.GS.RealmAbilities.AtlasOF_MasteryOfStealth' WHERE  `AbilityID`=273;```

2nd commit makes 3 levels RAs (3, 6, 10) use the same method instead of each having their own, and minor renaming.

By the way, the base class was pretty much already correct for OF (only missing the requirement), so if someday someone decides to switch to NF RAs, simply removing **AtlasOF_MasteryOfStealth** won't be enough. Shouldn't we revert it to its original NF state?