### PR TITLE
Fix Battery of Life double loop

### DIFF
--- a/GameServer/realmabilities_atlasOF/handlers/AtlasOF_BatteryOfLife.cs
+++ b/GameServer/realmabilities_atlasOF/handlers/AtlasOF_BatteryOfLife.cs
@@ -20,12 +20,7 @@ namespace DOL.GS.RealmAbilities
         {
             GamePlayer player = living as GamePlayer;
             if (CheckPreconditions(living, DEAD | SITTING | MEZZED | STUNNED)) return;
-            
-            foreach (GamePlayer visPlayer in player.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
-            {
-                SendCasterSpellEffectAndCastMessage(player, 7009, true);
-            }
-
+            SendCasterSpellEffectAndCastMessage(player, 7009, true);
             DisableSkill(living);
 
             new AtlasOF_BatteryOfLifeECSEffect(new ECSGameEffectInitParams(player, m_duration, 1, CreateSpell(living)));


### PR DESCRIPTION
SendCasterSpellEffectAndCastMessage() already loops through all players in radius and sends them the message + animation.

That double loop made Battery of Life play its animation n*n times and its message n times, n being the amount of players in range.