### PR TITLE
Fix players able to cast positive spells on enemies in some cases (#457)

### DIFF
--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -1024,7 +1024,7 @@ namespace DOL.GS.Spells
 						break;
 
 					case "realm":
-						if (GameServer.ServerRules.IsAllowedToAttack(Caster, selectedTarget, true))
+						if (!GameServer.ServerRules.IsAllowedToAttack(Caster, selectedTarget, true))
 						{
 							return false;
 						}


### PR DESCRIPTION
https://bug.atlasfreeshard.com/issues/457
Affects necromancer shades and players with PvP immunity (during login). Tested with heals only, not sure about buffs.