### PR TITLE
Fix charm effects persisting on the player when zoning (#96, #167)

### DIFF
--- a/GameServer/ECS-Effects/CharmECSEffect.cs
+++ b/GameServer/ECS-Effects/CharmECSEffect.cs
@@ -157,7 +157,7 @@ namespace DOL.GS
                 }
             }
             ECSPulseEffect song = EffectListService.GetPulseEffectOnTarget(casterPlayer);
-            if (charmMob != null && song != null && song.SpellHandler.Spell.InstrumentRequirement == 0 && !charmMob.IsWithinRadius(casterPlayer, SpellHandler.Spell.Range))
+            if (charmMob != null && song != null)
             {
                 EffectService.RequestImmediateCancelConcEffect(song);
             }

--- a/GameServer/spells/CharmSpellHandler.cs
+++ b/GameServer/spells/CharmSpellHandler.cs
@@ -524,7 +524,6 @@ namespace DOL.GS.Spells
         /// <param name="arguments"></param>
         public void ReleaseEventHandler(DOLEvent e, object sender, EventArgs arguments)
         {
-            Console.Write("Charm ReleaseEventHandler Called!");
             IControlledBrain npc = null;
             
             if (e == GameLivingEvent.PetReleased)


### PR DESCRIPTION
https://bug.atlasfreeshard.com/issues/96
https://bug.atlasfreeshard.com/issues/167

The pet would be released, but the charm effect on the caster would persist (can't be cancelled), then drain mana and show resist chance on each pulse.

This was caused by IsWithinRadius returning true due to the zone not being updated yet (mob zone == player zone). Removing IsWithinRadius' call doesn't seem to have any negative impact and effects are properly cancelled when out of range.

Also removed the song.SpellHandler.Spell.InstrumentRequirement check since it's always 0. Minstrel's charm doesn't require an instrument to be kept active (confirmed through debugging), and even if we did we probably want to cancel the effect anyway.