### PR TITLE
Fix swing delay when moving towards an enemy with weapon drawn

### DIFF
--- a/GameServer/ECS-Components/AttackComponent.cs
+++ b/GameServer/ECS-Components/AttackComponent.cs
@@ -1247,10 +1247,6 @@ namespace DOL.GS
                 AttackData ad = LivingMakeAttack(target, weapon, style, effectiveness * p.Effectiveness,
                     interruptDuration, dualWield);
 
-                //Clear the styles for the next round!
-                owner.styleComponent.NextCombatStyle = null;
-                owner.styleComponent.NextCombatBackupStyle = null;
-
                 switch (ad.AttackResult)
                 {
                     case eAttackResult.HitStyle:
@@ -3190,6 +3186,9 @@ namespace DOL.GS
         /// <param name="ad"></param>
         public void SendAttackingCombatMessages(AttackData ad)
         {
+            if (!attackAction.ShouldRoundShowMessage(ad.AttackResult))
+                return;
+
             //base.SendAttackingCombatMessages(ad);
             if (owner is GamePlayer)
             {

--- a/GameServer/ECS-Components/StyleComponent.cs
+++ b/GameServer/ECS-Components/StyleComponent.cs
@@ -46,13 +46,17 @@ namespace DOL.GS
         }
 
         /// <summary>
-		/// Holds the Style that this living should use next
+		/// Holds the style that this living should use next
 		/// </summary>
 		protected Style m_nextCombatStyle;
         /// <summary>
         /// Holds the backup style for the style that the living should use next
         /// </summary>
         protected Style m_nextCombatBackupStyle;
+        /// <summary>
+        /// Holds the time at which the style was set
+        /// </summary>
+        protected long m_nextCombatStyleTime;
 
         /// <summary>
         /// Gets or Sets the next combat style to use
@@ -69,6 +73,14 @@ namespace DOL.GS
         {
             get { return m_nextCombatBackupStyle; }
             set { m_nextCombatBackupStyle = value; }
+        }
+        /// <summary>
+        /// Gets or Sets the time at which the style was set
+        /// </summary>
+        public long NextCombatStyleTime
+        {
+            get { return m_nextCombatStyleTime; }
+            set { m_nextCombatStyleTime = value; }
         }
 
         /// <summary>
@@ -112,7 +124,7 @@ namespace DOL.GS
         }
 
         /// <summary>
-		/// Picks a style, prioritizing reactives an	d chains over positionals and anytimes
+		/// Picks a style, prioritizing reactives and chains over positionals and anytimes
 		/// </summary>
 		/// <returns>Selected style</returns>
 		public Style NPCGetStyleToUse()

--- a/GameServer/styles/StyleProcessor.cs
+++ b/GameServer/styles/StyleProcessor.cs
@@ -276,6 +276,7 @@ namespace DOL.GS.Styles
 
 						player.styleComponent.NextCombatStyle = style;
 						player.styleComponent.NextCombatBackupStyle = null;
+						player.styleComponent.NextCombatStyleTime = GameLoop.GameLoopTime;
 						player.Out.SendMessage(LanguageMgr.GetTranslation(player.Client.Account.Language, "StyleProcessor.TryToUseStyle.PreparePerform", style.Name), eChatType.CT_System, eChatLoc.CL_SystemWindow);
 
 						if (living.IsEngaging)


### PR DESCRIPTION
That one was more complicated to solve than I thought.

Currently, if you don't have a target, AttackAction.Tick() is called every 100ms. But when you have a target and your weapon is drawn, it's called at an interval equal to your weapon's attack speed. This is an issue because it means that if you move towards your target with your weapon drawn, you won't attack immediately. It's very noticeable with a slow weapon. This also affect styles, and if you reach your target right after a tick, you'll just perform an auto-attack. Players perceive this as lag (since it also looks random).

To solve this, I had to make it so that AttackAction.Tick() is called every 100ms as long as the last round doesn't result in an attack (regardless if it's a miss, a parried hit, etc.). Otherwise (so in actual combat) it's called at an interval equal to the weapon's attack speed. However, that made the "out of range" and "not in view" message very spamy, so that had to be taken care of too (see ShouldRoundShowMessage()). As for the styles, I decided to keep them active for a duration equal to the swing speed, but I'm not sure if that's the best way to do it.

This fix is needed to fix Nature's Shield (to make it so that it stays active).