### PR TITLE
Fix issues related to pet control (#524)

### DIFF
--- a/GameServer/ai/brain/ControlledNPCs/ControlledNPCState.cs
+++ b/GameServer/ai/brain/ControlledNPCs/ControlledNPCState.cs
@@ -120,11 +120,11 @@ public class ControlledNPCState_AGGRO : StandardMobState_AGGRO
             return;
         }
 
-        if (brain.WalkState == eWalkState.ComeHere)
+        /*if (brain.WalkState == eWalkState.ComeHere)
         {
             brain.FSM.SetCurrentState(eFSMStateType.IDLE);
             return;
-        }
+        }*/
         
         brain.CheckSpells(eCheckSpellType.Offensive);
 

--- a/GameServer/ai/brain/ControlledNPCs/ControlledNPCState.cs
+++ b/GameServer/ai/brain/ControlledNPCs/ControlledNPCState.cs
@@ -119,12 +119,6 @@ public class ControlledNPCState_AGGRO : StandardMobState_AGGRO
             brain.FSM.SetCurrentState(eFSMStateType.PASSIVE);
             return;
         }
-
-        /*if (brain.WalkState == eWalkState.ComeHere)
-        {
-            brain.FSM.SetCurrentState(eFSMStateType.IDLE);
-            return;
-        }*/
         
         brain.CheckSpells(eCheckSpellType.Offensive);
 

--- a/GameServer/ai/brain/ControlledNPCs/ControlledNpcBrain.cs
+++ b/GameServer/ai/brain/ControlledNPCs/ControlledNpcBrain.cs
@@ -240,21 +240,12 @@ namespace DOL.AI.Brain
 			set
 			{
 				m_aggressionState = value;
-				m_orderAttackTarget = null;
-				if (m_aggressionState == eAggressionState.Passive)
-				{
-					ClearAggroList();
-					Body.StopAttack();
-					Body.TargetObject = null;
+				Disengage();
 
-					FSM.SetCurrentState(eFSMStateType.PASSIVE);
-
-					if (WalkState == eWalkState.Follow)
-						FollowOwner();
-					else if (m_tempX > 0 && m_tempY > 0 && m_tempZ > 0)
-						Body.WalkTo(m_tempX, m_tempY, m_tempZ, Body.MaxSpeed);
-				}
-				//AttackMostWanted();
+				if (WalkState == eWalkState.Follow)
+					FollowOwner();
+				else if (m_tempX > 0 && m_tempY > 0 && m_tempZ > 0)
+					Body.WalkTo(m_tempX, m_tempY, m_tempZ, Body.MaxSpeed);
 			}
 		}
 
@@ -273,19 +264,24 @@ namespace DOL.AI.Brain
 			previousIsStealthed = false;
 			if (target is GamePlayer) 
 				previousIsStealthed = (target as GamePlayer).IsStealthed;
-
-			if (FSM.GetState(eFSMStateType.AGGRO) != FSM.GetCurrentState()){	FSM.SetCurrentState(eFSMStateType.AGGRO);}
+			FSM.SetCurrentState(eFSMStateType.AGGRO);
 			if (target != Body.TargetObject && Body.IsCasting)
 				Body.StopCurrentSpellcast();
 
-    //        if (Body.CanCastHarmfulSpells)
-    //        {
-				//CheckSpells(eCheckSpellType.Offensive);
-    //        } else
-    //        {
-				AttackMostWanted();
-			//}
-			
+			AttackMostWanted();
+		}
+
+		public virtual void Disengage()
+		{
+			if (AggressionState == eAggressionState.Aggressive && Body.TargetObject != null)
+			{
+				AggressionState = eAggressionState.Defensive;
+				UpdatePetWindow();
+			}
+			m_orderAttackTarget = null;
+			ClearAggroList();
+			Body.StopAttack();
+			Body.TargetObject = null;
 		}
 
 		/// <summary>

--- a/GameServer/ai/brain/IControlledBrain.cs
+++ b/GameServer/ai/brain/IControlledBrain.cs
@@ -67,6 +67,7 @@ namespace DOL.AI.Brain
         GameNPC Body { get; }
         GameLiving Owner { get; }
         void Attack(GameObject target);
+		void Disengage();
         void Follow(GameObject target);
         void FollowOwner();
         void Stay();

--- a/GameServer/ai/brain/NoveltyPetBrain.cs
+++ b/GameServer/ai/brain/NoveltyPetBrain.cs
@@ -86,6 +86,7 @@ namespace DOL.AI.Brain
 		public eAggressionState AggressionState { get { return eAggressionState.Passive; } set { } }
 		public GameLiving Owner { get { return m_owner; } }
 		public void Attack(GameObject target) { }
+		public void Disengage() { }
 		public void Follow(GameObject target) { }
 		public void FollowOwner() { }
 		public void Stay() { }

--- a/GameServer/ai/brain/ProcPetBrain.cs
+++ b/GameServer/ai/brain/ProcPetBrain.cs
@@ -79,6 +79,7 @@ namespace DOL.AI.Brain
 		public eAggressionState AggressionState { get { return eAggressionState.Aggressive; } set { } }
 		public GameLiving Owner { get { return m_owner; } }
 		public void Attack(GameObject target) { }
+		public void Disengage() { }
 		public void Follow(GameObject target) { }
 		public void FollowOwner() { }
 		public void Stay() { }

--- a/GameServer/ai/brain/Theurgist/TheurgistPetBrain.cs
+++ b/GameServer/ai/brain/Theurgist/TheurgistPetBrain.cs
@@ -204,6 +204,7 @@ namespace DOL.AI.Brain
 		public eAggressionState AggressionState { get { return eAggressionState.Aggressive; } set { } }
 		public GameLiving Owner { get { return m_owner; } }
 		public void Attack(GameObject target) { }
+		public void Disengage() { }
 		public void Follow(GameObject target) { }
 		public void FollowOwner() { }
 		public void Stay() { }

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -15650,6 +15650,7 @@ namespace DOL.GS
             }
 
             Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "GamePlayer.CommandNpcAttack.FollowYou", npc.Body.GetName(0, false)), eChatType.CT_System, eChatLoc.CL_SystemWindow);
+            npc.Disengage();
             npc.Follow(this);
         }
 
@@ -15669,6 +15670,7 @@ namespace DOL.GS
             }
 
             Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "GamePlayer.CommandNpcAttack.Stay", npc.Body.GetName(0, false)), eChatType.CT_System, eChatLoc.CL_SystemWindow);
+            npc.Disengage();
             npc.Stay();
         }
 
@@ -15688,6 +15690,7 @@ namespace DOL.GS
             }
 
             Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "GamePlayer.CommandNpcAttack.ComeHere", npc.Body.GetName(0, false)), eChatType.CT_System, eChatLoc.CL_SystemWindow);
+            npc.Disengage();
             npc.ComeHere();
         }
 
@@ -15720,6 +15723,7 @@ namespace DOL.GS
             }
 			
             Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "GamePlayer.CommandNpcAttack.GoToTarget", npc.Body.GetName(0, false)), eChatType.CT_System, eChatLoc.CL_SystemWindow);
+            npc.Disengage();
             npc.Goto(target);
         }
 

--- a/GameServer/serverrules/AbstractServerRules.cs
+++ b/GameServer/serverrules/AbstractServerRules.cs
@@ -400,12 +400,6 @@ namespace DOL.GS.ServerRules
 					return false;
 				}
 			}
-			// Your pet can only attack stealthed players you have selected
-			if (defender.IsStealthed && attacker is GameNPC)
-				if (((attacker as GameNPC).Brain is IControlledBrain) &&
-					defender is GamePlayer &&
-					attacker.TargetObject != defender)
-					return false;
 
 			// GMs can't be attacked
 			if (playerDefender != null && playerDefender.Client.Account.PrivLevel > 1)

--- a/Tests/UnitTests/FakeGameObjects.cs
+++ b/Tests/UnitTests/FakeGameObjects.cs
@@ -134,6 +134,7 @@ namespace DOL.Tests.Unit.Gameserver
         public eAggressionState AggressionState { get; set; }
         public bool IsMainPet { get; set; }
         public void Attack(GameObject target) { }
+        public void Disengage() { }
         public void ComeHere() { }
         public void Follow(GameObject target) { }
         public void FollowOwner() { }


### PR DESCRIPTION
1. Pets follow stealthed targets but don't attack them.
This is caused by a bit of code that apparently was supposed to allow pets to attack sheathed players only if the owner is targeting them, but `attacker.TargetObject` is always null. I removed the whole check because I don't see the point. Even on aggro they don't automatically attack anyway.

2. Having a pet in "here" mode and ordering it to attack would make the pet follow the target without attacking it. This was simply caused by ControlledNPCState_AGGRO.Think() returning immediately. I'm not sure what was the point of that check. Another solution would have been to cancel the "here" order when ordering the pet to attack, and when it finds a target by itself when on aggro, but I don't think the follow / stay / go / here orders are supposed to change like that.

3. When a pet has a target, any movement order would make it stop then resume it's original attack. It looks very bad. Either these orders should have absolutely no effect until the target is lost or the owner set the pet on passive, or they should clear the aggro and cancel the attack like the passive command does. The second option makes more sense to me but I'm not sure if it's accurate with how the game should behave. With this fix, follow / stay / go / here do just that, and also set the pet on defensive if it had a target to avoid it attacking again almost immediately.
