### PR TITLE
Fix engage clunkiness

### DIFF
--- a/GameServer/ECS-Effects/EngageECSEffect.cs
+++ b/GameServer/ECS-Effects/EngageECSEffect.cs
@@ -68,14 +68,11 @@ namespace DOL.GS
         public override void OnStopEffect()
         {
             Owner.IsEngaging = false;
+            Owner.attackComponent.StartAttack(Owner.TargetObject);
         }
 
         public void Cancel(bool playerCancel)
         {
-            Owner.attackComponent.AttackState = false;
-            if (Owner is GamePlayer)
-                (Owner as GamePlayer).Out.SendAttackMode(false);
-
             EffectService.RequestImmediateCancelEffect(this, playerCancel);
             if (OwnerPlayer != null)
             {

--- a/GameServer/packets/Client/168/PlayerAttackRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerAttackRequestHandler.cs
@@ -73,7 +73,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 					return 0;
 				}
 
-				if (m_start || EffectListService.GetEffectOnTarget(player, eEffect.Engage) != null)
+				if (m_start)
 				{
 					player.attackComponent.StartAttack(player.TargetObject);
 					// unstealth right after entering combat mode if anything is targeted

--- a/GameServer/skillhandler/EngageAbilityHandler.cs
+++ b/GameServer/skillhandler/EngageAbilityHandler.cs
@@ -59,18 +59,18 @@ namespace DOL.GS.SkillHandler
 					log.Warn("Could not retrieve player in EngageAbilityHandler.");
 				return;
 			}
-			/*
+
 			//Cancel old engage effects on player
 			if (player.IsEngaging)
 			{
-				EngageEffect engage = (EngageEffect)player.EffectList.GetOfType(typeof(EngageEffect));
+				EngageECSGameEffect engage = EffectListService.GetEffectOnTarget(player, eEffect.Engage) as EngageECSGameEffect;
 				if (engage != null)
 				{
-					engage.Cancel(false);
+					engage.Cancel(true);
 					return;
 				}
 			}
-			 */
+
 			if (!player.IsAlive)
 			{
                 player.Out.SendMessage(LanguageMgr.GetTranslation(player.Client.Account.Language, "Skill.Ability.Engage.CannotUseDead"), eChatType.CT_YouHit, eChatLoc.CL_SystemWindow);
@@ -108,16 +108,7 @@ namespace DOL.GS.SkillHandler
                 player.Out.SendMessage(LanguageMgr.GetTranslation(player.Client.Account.Language, "Skill.Ability.Engage.NotAllowedToEngageTarget", target.GetName(0, false)), eChatType.CT_System, eChatLoc.CL_SystemWindow);
                 return;
 			}
-			//Cancel old engage effects on player
 
-			foreach (EngageECSGameEffect engage in player.effectListComponent.GetAllEffects().Where(e => e.EffectType == eEffect.Engage))
-			{ 
-				if (engage != null)
-				{
-					engage.Cancel(false);
-					return;
-				}
-			}
 			new EngageECSGameEffect(new ECSGameEffectInitParams(player, 0, 1, null));
 		}
 	}


### PR DESCRIPTION
Being in engage mode and using a style or entering actual combat mode makes the character sheathe and draw his weapon very quickly. Both sound effects play at the same time. I tried to find a way to prevent that.

Cancelling engage by using the ability makes the character sheathe his weapon. Instead, the character now stays in attack mode (it's still possible to sheathe normally).