### PR TITLE
Remove useless busy-wait loops

### DIFF
--- a/GameServer/managers/GameLoopManager/AuxGameLoop.cs
+++ b/GameServer/managers/GameLoopManager/AuxGameLoop.cs
@@ -47,17 +47,7 @@ namespace DOL.GS
 
         private static void GameLoopThreadStart()
         {
-            bool running = true;
             _timerRef = new Timer(Tick, null, 0, Timeout.Infinite);
-
-            while (running)
-            {
-                try { }
-                catch (ThreadInterruptedException)
-                {
-                    running = false;
-                }
-            }
         }
 
         private static void Tick(object obj)

--- a/GameServer/managers/GameLoopManager/GameLoop.cs
+++ b/GameServer/managers/GameLoopManager/GameLoop.cs
@@ -43,17 +43,7 @@ namespace DOL.GS
 
         private static void GameLoopThreadStart()
         {
-            bool running = true;
             _timerRef = new Timer(Tick, null, 0, Timeout.Infinite);
-
-            while (running)
-            {
-                try { }
-                catch (ThreadInterruptedException)
-                {
-                    running = false;
-                }
-            }
         }
 
         private static void Tick(object obj)


### PR DESCRIPTION
Is there some subtlety I'm missing? It's two loop doing nothing but stalling two cores at 100%. I don't know about the actual negative performance impact they have when other threads ask for CPU-time but I'm definitely noticing fewer long timer on my local environment (only 4 cores).