### PR TITLE
Fix spellcasting

### DIFF
--- a/GameServer/ECS-Components/AttackComponent.cs
+++ b/GameServer/ECS-Components/AttackComponent.cs
@@ -1523,7 +1523,7 @@ namespace DOL.GS
             //Check if the target is in front of attacker
             if (!ignoreLOS && ad.AttackType != AttackData.eAttackType.Ranged && owner is GamePlayer &&
                 !(ad.Target is GameKeepComponent) &&
-                !(owner.IsObjectInFront(ad.Target, 120, true) && owner.TargetInView))
+                !(owner.IsObjectInFront(ad.Target, 120) && owner.TargetInView))
             {
                 ad.AttackResult = eAttackResult.TargetNotVisible;
                 SendAttackingCombatMessages(ad);

--- a/GameServer/gameobjects/GameObject.cs
+++ b/GameServer/gameobjects/GameObject.cs
@@ -317,7 +317,7 @@ namespace DOL.GS
 		/// <param name="viewangle"></param>
 		/// <param name="rangeCheck"></param>
 		/// <returns></returns>
-		public virtual bool IsObjectInFront(GameObject target, double viewangle, bool rangeCheck = true)
+		public virtual bool IsObjectInFront(GameObject target, double viewangle, int alwaysTrueRange = 32)
 		{
 			if (target == null)
 				return false;
@@ -326,8 +326,8 @@ namespace DOL.GS
 				return true;
 			// if target is closer than 32 units it is considered always in view
 			// tested and works this way for normal evade, parry, block (in 1.69)
-			if (rangeCheck)
-                return this.IsWithinRadius( target, 32 );
+			if (alwaysTrueRange > 0)
+                return this.IsWithinRadius(target, alwaysTrueRange);
 			else
                 return false;
 		}

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -170,11 +170,15 @@ namespace DOL.GS
         /// </summary>
         public override bool TargetInView
         {
-            get {
-                if(TargetObject != null && ((TargetObject is GamePlayer {IsMoving: true} p && GetDistanceTo(p) < 100) || GetDistanceTo(TargetObject) < 64))
-                    return true; 
-                else
-                    return m_targetInView; }
+            get
+            {
+                GamePlayer targetPlayer = TargetObject as GamePlayer;
+
+                if (targetPlayer != null && targetPlayer.IsMoving ? GetDistanceTo(targetPlayer) < 100 : GetDistanceTo(targetPlayer) < 64)
+                    return true;
+
+                return m_targetInView;
+            }
             set { m_targetInView = value; }
         }
 

--- a/GameServer/keeps/Gameobjects/GameKeepDoor.cs
+++ b/GameServer/keeps/Gameobjects/GameKeepDoor.cs
@@ -476,7 +476,7 @@ namespace DOL.GS.Keeps
 				{
 					//when entering a tower, we need to raise Z
 					//portal keeps are considered towers too, so we check component count
-					if (IsObjectInFront(player, 180, false))
+					if (IsObjectInFront(player, 180))
 					{
 						if (DoorID == 1)
 						{
@@ -491,7 +491,7 @@ namespace DOL.GS.Keeps
 				else
 				{
 					//when entering a keeps inner door, we need to raise Z
-					if (IsObjectInFront(player, 180, false))
+					if (IsObjectInFront(player, 180))
 					{
 						//To find out if a door is the keeps inner door, we compare the distance between
 						//the component for the keep and the component for the gate
@@ -518,7 +518,7 @@ namespace DOL.GS.Keeps
 
                 Point2D keepPoint;
 				//calculate x y
-				if (IsObjectInFront(player, 180, false))
+				if (IsObjectInFront(player, 180))
 					keepPoint = GetPointFromHeading(Heading, -distance );
 				else
 					keepPoint = GetPointFromHeading(Heading, distance );

--- a/GameServer/keeps/Gameobjects/GameRelicDoor.cs
+++ b/GameServer/keeps/Gameobjects/GameRelicDoor.cs
@@ -157,10 +157,10 @@ namespace DOL.GS.Keeps
 			{
                 Point2D point;
 				//calculate x y
-                if ( IsObjectInFront( player, 180, false ) )
-                    point = this.GetPointFromHeading( this.Heading, -500 );
+                if (IsObjectInFront(player, 180) )
+                    point = this.GetPointFromHeading(this.Heading, -500);
                 else
-                    point = this.GetPointFromHeading( this.Heading, 500 );
+                    point = this.GetPointFromHeading(this.Heading, 500);
 
 				//move player
 				player.MoveTo(CurrentRegionID, point.X, point.Y, player.Z, player.Heading);

--- a/GameServer/keeps/Gameobjects/Guards/GameKeepGuard.cs
+++ b/GameServer/keeps/Gameobjects/Guards/GameKeepGuard.cs
@@ -617,7 +617,7 @@ namespace DOL.GS.Keeps
 		/// <param name="target"></param>
 		/// <param name="viewangle"></param>
 		/// <returns></returns>
-		public override bool IsObjectInFront(GameObject target, double viewangle, bool rangeCheck = true)
+		public override bool IsObjectInFront(GameObject target, double viewangle, int alwaysTrueRange = 32)
 		{
 			return true;
 		}

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -1307,13 +1307,6 @@ namespace DOL.GS.Spells
 						}
 						break;
 
-					case "Realm":
-						if (GameServer.ServerRules.IsAllowedToAttack(Caster, target, true))
-						{
-							return false;
-						}
-						break;
-
 					case "Pet":
 						/*
 						 * [Ganrod] Nidel: Can cast pet spell on all Pet/Turret/Minion (our pet)
@@ -1524,13 +1517,6 @@ namespace DOL.GS.Spells
 						}
 						break;
 
-					case "realm":
-						if (GameServer.ServerRules.IsAllowedToAttack(Caster, target, true))
-						{
-							return false;
-						}
-						break;
-
 					case "pet":
 						/*
 						 * Can cast pet spell on all Pet/Turret/Minion (our pet)
@@ -1598,7 +1584,6 @@ namespace DOL.GS.Spells
 		{
 			return CheckAfterCast(target, false);
 		}
-
 
 		public virtual bool CheckAfterCast(GameLiving target, bool quiet)
 		{
@@ -1709,13 +1694,6 @@ namespace DOL.GS.Spells
 						if (target.IsAlive || !GameServer.ServerRules.IsSameRealm(Caster, target, quiet))
 						{
 							if (!quiet) MessageToCaster("This spell only works on dead members of your realm!", eChatType.CT_SpellResisted);
-							return false;
-						}
-						break;
-
-					case "Realm":
-						if (GameServer.ServerRules.IsAllowedToAttack(Caster, target, true))
-						{
 							return false;
 						}
 						break;

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -1002,7 +1002,7 @@ namespace DOL.GS.Spells
 							return false;
 						}
 
-						if (!(m_caster.IsObjectInFront(selectedTarget, 180, true)) || !Caster.TargetInView)
+						if (!(m_caster.IsObjectInFront(selectedTarget, 180)) || !Caster.TargetInView)
 						{
 							if (!quiet) MessageToCaster("Your target is not visible!", eChatType.CT_SpellResisted);
 							Caster.Notify(GameLivingEvent.CastFailed, new CastFailedEventArgs(this, CastFailedEventArgs.Reasons.TargetNotInView));
@@ -1285,11 +1285,17 @@ namespace DOL.GS.Spells
 					case "Enemy":
 						if (m_spell.SpellType == (byte)eSpellType.Charm)
 							break;
-						//enemys have to be in front and in view for targeted spells
-						if (m_spell.SpellType != (byte)eSpellType.PetSpell && (target.IsStealthed || !Caster.TargetInView)) //!m_caster.TargetInView)
+
+						if (m_spell.SpellType != (byte)eSpellType.PetSpell)
 						{
-							MessageToCaster("Your target is not in view. The spell fails.", eChatType.CT_SpellResisted);
-							return false;
+							// The target must be visible and in front of the caster
+							// Thankfully TargetInView seems to return false if the target hides behind a wall, even if the caster selects a new target during the animation
+							// We don't give a radius to IsObjectInFront. A check is already done in TargetInView
+							if (target.IsStealthed || !Caster.TargetInView || !Caster.IsObjectInFront(target, 180, 0))
+							{
+								MessageToCaster("You can't see your target from here!", eChatType.CT_SpellResisted);
+								return false;
+							}
 						}
 
 						if (!GameServer.ServerRules.IsAllowedToAttack(Caster, target, false))
@@ -1553,6 +1559,7 @@ namespace DOL.GS.Spells
 				if (!quiet) MessageToCaster("You have exhausted all of your power and cannot cast spells!", eChatType.CT_SpellResisted);
 				return false;
 			}
+
 			if (Spell.Power != 0 && m_caster.Mana < PowerCost(target) && EffectListService.GetAbilityEffectOnTarget(Caster, eEffect.QuickCast) == null && Spell.SpellType != (byte)eSpellType.Archery)
 			{
 				if (!quiet) MessageToCaster("You don't have enough power to cast that!", eChatType.CT_SpellResisted);
@@ -2966,7 +2973,7 @@ namespace DOL.GS.Spells
 							if (player == Caster)
 								return;
 
-							if (!m_caster.IsObjectInFront(player, (double)(Spell.Radius != 0 ? Spell.Radius : 100), false))
+							if (!m_caster.IsObjectInFront(player, (double)(Spell.Radius != 0 ? Spell.Radius : 100)))
 								return;
 
 							if (!GameServer.ServerRules.IsAllowedToAttack(Caster, player, true))
@@ -2982,7 +2989,7 @@ namespace DOL.GS.Spells
 							if (npc == Caster)
 								return;
 
-							if (!m_caster.IsObjectInFront(npc, (double)(Spell.Radius != 0 ? Spell.Radius : 100), false))
+							if (!m_caster.IsObjectInFront(npc, (double)(Spell.Radius != 0 ? Spell.Radius : 100)))
 								return;
 
 							if (!GameServer.ServerRules.IsAllowedToAttack(Caster, npc, true))

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -1024,7 +1024,7 @@ namespace DOL.GS.Spells
 						break;
 
 					case "realm":
-						if (!GameServer.ServerRules.IsAllowedToAttack(Caster, selectedTarget, true))
+						if (!GameServer.ServerRules.IsSameRealm(Caster, selectedTarget, true))
 						{
 							return false;
 						}


### PR DESCRIPTION
Last commits broke "realm" spells due to IsAllowedToAttack being weird with beneficial spells. Instead of trying to make it work, I decided to check the target's realm instead. This should work even on different server rules.

This however revealed that IsAllowedToAttack was used in other places, and made for example GMs unable to buff players from another realm (the animation would start but get cancelled in CheckDuringCast).

Third commit fixes player able to finish their cast on mobs while having their back turned. It also allows spells to finish even if the caster unselects their target (live-like).