### PR TITLE
Currency generalization

### DIFF
--- a/GameServer/gameobjects/GameMerchant.cs
+++ b/GameServer/gameobjects/GameMerchant.cs
@@ -852,16 +852,15 @@ namespace DOL.GS
 	// checks for achievement completion at realm level
 	public class GameAtlasMerchant : GameItemCurrencyMerchant
 	{
-		//Atlas Orbs itemtemplate = token_many
-		public override string MoneyKey { get { return "token_many"; } }
+		public override string MoneyKey { get; } = ServerProperties.Properties.ALT_CURRENCY_ID; // remember to set this in server properties
 
-		public override void OnPlayerBuy(GamePlayer player, int item_slot, int number)
+		public override void OnPlayerBuy(GamePlayer player, int itemSlot, int number)
 		{
 			if (m_moneyItem == null || m_moneyItem.Item == null)
 				return;
 			//Get the template
-			int pagenumber = item_slot / MerchantTradeItems.MAX_ITEM_IN_TRADEWINDOWS;
-			int slotnumber = item_slot % MerchantTradeItems.MAX_ITEM_IN_TRADEWINDOWS;
+			int pagenumber = itemSlot / MerchantTradeItems.MAX_ITEM_IN_TRADEWINDOWS;
+			int slotnumber = itemSlot % MerchantTradeItems.MAX_ITEM_IN_TRADEWINDOWS;
 
 			ItemTemplate template = this.TradeItems.GetItem(pagenumber, (eMerchantWindowSlot)slotnumber);
 			if (template == null) return;
@@ -952,10 +951,8 @@ namespace DOL.GS
 	// checks for achievement completion at account level
 	public class AtlasAchievementMerchant : GameItemCurrencyMerchant
 	{
-		//Atlas Orbs itemtemplate = token_many
-		public override string MoneyKey { get { return "token_many"; } }
+		public override string MoneyKey { get; } = ServerProperties.Properties.ALT_CURRENCY_ID; // remember to set this in server properties
 
-		
 		public override void OnPlayerBuy(GamePlayer player, int item_slot, int number)
 		{
 			if (m_moneyItem == null || m_moneyItem.Item == null)

--- a/GameServer/keeps/Gameobjects/Guards/GameGuardMerchant.cs
+++ b/GameServer/keeps/Gameobjects/Guards/GameGuardMerchant.cs
@@ -733,7 +733,7 @@ namespace DOL.GS
 	public class GameAtlasGuardMerchant : GameItemCurrencyGuardMerchant
 	{
 		//Atlas Orbs itemtemplate = token_many
-		public override string MoneyKey { get { return "token_many"; } }
+		public override string MoneyKey { get; } = ServerProperties.Properties.ALT_CURRENCY_ID; // remember to set this in server properties
 
 		public override void OnPlayerBuy(GamePlayer player, int item_slot, int number)
 		{

--- a/GameServer/managers/RandomObjectGeneration/AtlasROGManager.cs
+++ b/GameServer/managers/RandomObjectGeneration/AtlasROGManager.cs
@@ -12,6 +12,8 @@ namespace DOL.GS {
     public static class AtlasROGManager {
 
         private static ItemTemplate beadTemplate = null;
+        
+        private static string _currencyID = ServerProperties.Properties.ALT_CURRENCY_ID;
 
         public static void GenerateROG(GameLiving living)
         {
@@ -125,8 +127,14 @@ namespace DOL.GS {
             if (living != null && living is GamePlayer)
             {
                 var player = living as GamePlayer;
-
-                var orbs = GameServer.Database.FindObjectByKey<ItemTemplate>("token_many");
+                
+                var orbs = GameServer.Database.FindObjectByKey<ItemTemplate>(_currencyID);
+                
+                if (orbs == null)
+                {
+                    player.Out.SendMessage("Error: Currency ID not found!", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+                    return;
+                }
 
                 InventoryItem item = GameInventoryItem.Create(orbs);
 

--- a/GameServer/scripts/AtlasEvents/BattlegroundEventLoot.cs
+++ b/GameServer/scripts/AtlasEvents/BattlegroundEventLoot.cs
@@ -17,6 +17,8 @@ namespace DOL.GS.Scripts
 		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 		private static int freeLootLevelOffset = 2;
 		private int playerRewardOffset = 6;
+		
+		private static string _currencyID = ServerProperties.Properties.ALT_CURRENCY_ID;
         public override bool AddToWorld()
         {
             Model = 2026;
@@ -194,12 +196,7 @@ namespace DOL.GS.Scripts
 				charFreeEventMoney.Value = "1";
 				GameServer.Database.AddObject(charFreeEventMoney);
 
-				//ItemTemplate orbs = GameServer.Database.FindObjectByKey<ItemTemplate>("token_many");
-			
-				//InventoryItem item = GameInventoryItem.Create(orbs);
 				player.AddMoney(5000000);
-			
-				//player.Inventory.AddTemplate(item, 10000, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
 			}
 			else if (str.Equals("Atlas Orbs"))
 			{
@@ -220,7 +217,13 @@ namespace DOL.GS.Scripts
 				charFreeEventMoney.Value = "15000";
 				GameServer.Database.AddObject(charFreeEventMoney);
 
-				ItemTemplate orbs = GameServer.Database.FindObjectByKey<ItemTemplate>("token_many");
+				ItemTemplate orbs = GameServer.Database.FindObjectByKey<ItemTemplate>(_currencyID);
+				
+				if (orbs == null)
+				{
+					player.Out.SendMessage("Error: Currency ID not found!", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+					return false;
+				}
 
 				InventoryItem item = GameInventoryItem.Create(orbs);
 

--- a/GameServer/scripts/customnpc/AccountVaultKeeper.cs
+++ b/GameServer/scripts/customnpc/AccountVaultKeeper.cs
@@ -294,7 +294,7 @@ namespace DOL.GS
             // block placing untradables into housing vaults from any source - Tolakram
             if (toAccountVault && itemInFromSlot != null && itemInFromSlot.IsTradable == false)
             {
-                if (itemInFromSlot.Id_nb != "token_many")
+                if (itemInFromSlot.Id_nb != ServerProperties.Properties.ALT_CURRENCY_ID)
                 {
                     player.Out.SendMessage("You can not put this item into an Account Vault!", eChatType.CT_System, eChatLoc.CL_SystemWindow);
                     player.Out.SendInventoryItemsUpdate(null);

--- a/GameServer/scripts/customnpc/AchievementReskinVendor.cs
+++ b/GameServer/scripts/customnpc/AchievementReskinVendor.cs
@@ -15,6 +15,9 @@ public class AchievementReskinVendor : GameNPC
     public string TempModelID = "TempModelID";
     public string TempModelPrice = "TempModelPrice";
     public string currencyName = "Orbs";
+    
+    private string _currencyID = ServerProperties.Properties.ALT_CURRENCY_ID;
+
     private int Chance;
     private Random rnd = new Random();
     private List<SkinVendorItem> VendorItemList = new List<SkinVendorItem>();
@@ -61,7 +64,7 @@ public class AchievementReskinVendor : GameNPC
     public override bool ReceiveItem(GameLiving source, InventoryItem item)
     {
         GamePlayer t = source as GamePlayer;
-        if (t == null || item == null || item.Template.Name.Equals("token_many")) return false;
+        if (t == null || item == null || item.Template.Name.Equals(_currencyID)) return false;
         if (GetDistanceTo(t) > WorldMgr.INTERACT_DISTANCE)
         {
             t.Out.SendMessage("You are too far away to give anything to " + GetName(0, false) + ".",
@@ -236,7 +239,7 @@ public class AchievementReskinVendor : GameNPC
     {
         if (price > 0)
         {
-            int playerOrbs = player.Inventory.CountItemTemplate("token_many", eInventorySlot.FirstBackpack,
+            int playerOrbs = player.Inventory.CountItemTemplate(_currencyID, eInventorySlot.FirstBackpack,
                 eInventorySlot.LastBackpack);
             log.Info("Player Orbs:" + playerOrbs);
 
@@ -309,7 +312,7 @@ public class AchievementReskinVendor : GameNPC
             //player.RealmPoints -= price;
             //player.RespecRealm();
             //SetRealmLevel(player, (int)player.RealmPoints);
-            player.Inventory.RemoveTemplate("token_many", price, eInventorySlot.FirstBackpack,
+            player.Inventory.RemoveTemplate(_currencyID, price, eInventorySlot.FirstBackpack,
                 eInventorySlot.LastBackpack);
 
             player.SaveIntoDatabase();
@@ -325,7 +328,7 @@ public class AchievementReskinVendor : GameNPC
     {
         if (price > 0)
         {
-            int playerOrbs = player.Inventory.CountItemTemplate("token_many", eInventorySlot.FirstBackpack,
+            int playerOrbs = player.Inventory.CountItemTemplate(_currencyID, eInventorySlot.FirstBackpack,
                 eInventorySlot.LastBackpack);
             //log.Info("Player Orbs:" + playerOrbs);
 
@@ -386,7 +389,7 @@ public class AchievementReskinVendor : GameNPC
             //player.RealmPoints -= price;
             //player.RespecRealm();
             //SetRealmLevel(player, (int)player.RealmPoints);
-            player.Inventory.RemoveTemplate("token_many", price, eInventorySlot.FirstBackpack,
+            player.Inventory.RemoveTemplate(_currencyID, price, eInventorySlot.FirstBackpack,
                 eInventorySlot.LastBackpack);
 
             player.SaveIntoDatabase();

--- a/GameServer/scripts/customnpc/EffectNPC.cs
+++ b/GameServer/scripts/customnpc/EffectNPC.cs
@@ -36,6 +36,8 @@ namespace DOL.GS {
         public string DisplayedItem = "EffectDisplay";
         public string TempEffectId = "TempEffectID";
         public string TempColorId = "TempColorID";
+        private string _currencyID = ServerProperties.Properties.ALT_CURRENCY_ID;
+
 
 
         public override bool AddToWorld()
@@ -76,7 +78,7 @@ namespace DOL.GS {
 
         public override bool ReceiveItem(GameLiving source, InventoryItem item)
         {
-            if (source == null || item == null || item.Id_nb == "token_many") return false;
+            if (source == null || item == null || item.Id_nb == _currencyID) return false;
             if (source is GamePlayer p)
             {
                 SendReply(p, "What service do you want to use ?\n" +
@@ -995,7 +997,7 @@ namespace DOL.GS {
                 return;
             }
 
-            int playerOrbs = player.Inventory.CountItemTemplate("token_many", eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
+            int playerOrbs = player.Inventory.CountItemTemplate(_currencyID, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
             log.Info("Player Orbs:" + playerOrbs);
 
             if (playerOrbs < price)
@@ -1033,7 +1035,7 @@ namespace DOL.GS {
             //player.RealmPoints -= price;
             //player.RespecRealm();
             //SetRealmLevel(player, (int)player.RealmPoints);
-            player.Inventory.RemoveTemplate("token_many", price, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
+            player.Inventory.RemoveTemplate(_currencyID, price, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
 
             player.TempProperties.removeProperty(TempProperty);
             player.TempProperties.removeProperty(DisplayedItem);
@@ -1097,7 +1099,7 @@ namespace DOL.GS {
                 return;
             }
 
-            int playerOrbs = player.Inventory.CountItemTemplate("token_many", eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
+            int playerOrbs = player.Inventory.CountItemTemplate(_currencyID, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
             log.Info("Player Orbs:" + playerOrbs);
 
             if (playerOrbs < price)
@@ -1136,7 +1138,7 @@ namespace DOL.GS {
             //player.RealmPoints -= price;
             //player.RespecRealm();
             //SetRealmLevel(player, (int)player.RealmPoints);
-            player.Inventory.RemoveTemplate("token_many", price, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
+            player.Inventory.RemoveTemplate(_currencyID, price, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
 
             player.TempProperties.removeProperty(TempProperty);
             player.TempProperties.removeProperty(DisplayedItem);

--- a/GameServer/scripts/customnpc/ItemModel.cs
+++ b/GameServer/scripts/customnpc/ItemModel.cs
@@ -19,6 +19,7 @@ namespace DOL.GS {
         public string TempModelID = "TempModelID";
         public string TempModelPrice = "TempModelPrice";
         public string currencyName = "Orbs";
+        private string _currencyID = ServerProperties.Properties.ALT_CURRENCY_ID;
         private int Chance;
         private Random rnd = new Random();
 
@@ -6058,7 +6059,7 @@ namespace DOL.GS {
         public override bool ReceiveItem(GameLiving source, InventoryItem item)
         {
             GamePlayer t = source as GamePlayer;
-            if (t == null || item == null|| item.Id_nb == "token_many") return false;
+            if (t == null || item == null|| item.Id_nb == _currencyID) return false;
             if (GetDistanceTo(t) > WorldMgr.INTERACT_DISTANCE)
             {
                 t.Out.SendMessage("You are too far away to give anything to " + GetName(0, false) + ".", eChatType.CT_System, eChatLoc.CL_SystemWindow);
@@ -6721,7 +6722,7 @@ namespace DOL.GS {
         {
             if (price > 0)
             {
-                int playerOrbs = player.Inventory.CountItemTemplate("token_many", eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
+                int playerOrbs = player.Inventory.CountItemTemplate(_currencyID, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
                 log.Info("Player Orbs:" + playerOrbs);
 
                 if (playerOrbs < price)
@@ -6759,7 +6760,7 @@ namespace DOL.GS {
                 //player.RealmPoints -= price;
                 //player.RespecRealm();
                 //SetRealmLevel(player, (int)player.RealmPoints);
-                player.Inventory.RemoveTemplate("token_many", price, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
+                player.Inventory.RemoveTemplate(_currencyID, price, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
 
                 player.SaveIntoDatabase();
                 return true;
@@ -6774,7 +6775,7 @@ namespace DOL.GS {
         {
             if (price > 0)
             {
-                int playerOrbs = player.Inventory.CountItemTemplate("token_many", eInventorySlot.FirstBackpack,eInventorySlot.LastBackpack);
+                int playerOrbs = player.Inventory.CountItemTemplate(_currencyID, eInventorySlot.FirstBackpack,eInventorySlot.LastBackpack);
                 //log.Info("Player Orbs:" + playerOrbs);
 
                 if (playerOrbs < price)
@@ -6811,7 +6812,7 @@ namespace DOL.GS {
                 //player.RealmPoints -= price;
                 //player.RespecRealm();
                 //SetRealmLevel(player, (int)player.RealmPoints);
-                player.Inventory.RemoveTemplate("token_many", price, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
+                player.Inventory.RemoveTemplate(_currencyID, price, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack);
 
                 player.SaveIntoDatabase();
 

--- a/GameServer/scripts/customnpc/LootGenExpOrb.cs
+++ b/GameServer/scripts/customnpc/LootGenExpOrb.cs
@@ -30,7 +30,8 @@ namespace DOL.GS
     public class LootGeneratorExpOrb : LootGeneratorBase
     {
 
-        private static ItemTemplate m_token_many = GameServer.Database.FindObjectByKey<ItemTemplate>("token_many");
+        private static string _currencyID = ServerProperties.Properties.ALT_CURRENCY_ID;
+        private static ItemTemplate m_token_many = GameServer.Database.FindObjectByKey<ItemTemplate>(_currencyID);
 
         /// <summary>
         /// Generate loot for given mob

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -2958,6 +2958,9 @@ namespace DOL.GS.ServerProperties
         
         [ServerProperty("atlas", "patch_notes_url", "The URL of the remote patch notes .txt to display with /sn", "")]
         public static string PATCH_NOTES_URL;
+        
+        [ServerProperty("atlas", "alt_currency_id", "The id_nb of the item to use as alternative currency (i.e. Orbs)", "")]
+        public static string ALT_CURRENCY_ID;
 
 		#endregion
 		public static IDictionary<string, object> AllCurrentProperties


### PR DESCRIPTION
We had many hard references to the Atlas Orbs id_nb in our code.
With the id_nb exposed as serverproperty, the intent is to allow an easy configuration and switch of all the bespoke currency merchants/vendors to any given currency the team should decide to use.

There's some additional work to allow switching between any given alternate currency as Orbs and BP but that will be on another MR.

DB has already been updated.

```sql
INSERT INTO `serverproperty` (`Category`, `Key`, `Description`, `DefaultValue`, `Value`, `LastTimeRowUpdated`, `ServerProperty_ID`) VALUES ('atlas', 'alt_currency_id', 'The id_nb of the item to use as alternative currency (i.e. Orbs)', '', 'token_many', '2022-10-31 10:27:49', '64e0b3ca-872c-4a81-bab8-31b6b3022d30');
```

