### PR TITLE
Generate reward

### DIFF
--- a/GameServer/gameobjects/Dragons/GameDragon.cs
+++ b/GameServer/gameobjects/Dragons/GameDragon.cs
@@ -59,7 +59,7 @@ namespace DOL.GS
         protected String m_glareAnnounce;
         protected String[] m_deathAnnounce;
 
-        private int OrbsReward = Properties.EPICBOSS_ORBS;
+        private int Reward = Properties.EPICBOSS_ORBS;
 
         /// <summary>
         /// Creates a new instance of GameDragon.
@@ -226,7 +226,7 @@ namespace DOL.GS
                             if (bgPlayer.IsWithinRadius(this, WorldMgr.MAX_EXPFORKILL_DISTANCE))
                             {
                                 if (bgPlayer.Level < 45) continue;
-                                AtlasROGManager.GenerateOrbAmount(bgPlayer, OrbsReward);
+                                AtlasROGManager.GenerateReward(bgPlayer, Reward);
                                 AtlasROGManager.GenerateBeetleCarapace(bgPlayer);
                                 bgPlayer.Achieve($"{achievementMob}-Credit");
                             }
@@ -240,7 +240,7 @@ namespace DOL.GS
                         if (groupPlayer.IsWithinRadius(this, WorldMgr.MAX_EXPFORKILL_DISTANCE))
                         {
                             if (groupPlayer.Level < 45) continue;
-                            AtlasROGManager.GenerateOrbAmount(groupPlayer, OrbsReward);
+                            AtlasROGManager.GenerateReward(groupPlayer, Reward);
                             AtlasROGManager.GenerateBeetleCarapace(groupPlayer);
                             groupPlayer.Achieve($"{achievementMob}-Credit");
                         }
@@ -250,7 +250,7 @@ namespace DOL.GS
                 {
                     if (playerKiller.Level >= 45)
                     {
-                        AtlasROGManager.GenerateOrbAmount(playerKiller, OrbsReward);
+                        AtlasROGManager.GenerateReward(playerKiller, Reward);
                         AtlasROGManager.GenerateBeetleCarapace(playerKiller);
                         playerKiller.Achieve($"{achievementMob}-Credit"); ;
                     }

--- a/GameServer/gameobjects/GameEpicBoss.cs
+++ b/GameServer/gameobjects/GameEpicBoss.cs
@@ -77,7 +77,7 @@ namespace DOL.GS {
                             if (bgPlayer.IsWithinRadius(this, WorldMgr.MAX_EXPFORKILL_DISTANCE))
                             {
                                 if (bgPlayer.Level < 45) continue;
-                                AtlasROGManager.GenerateOrbAmount(bgPlayer,OrbsReward);
+                                AtlasROGManager.GenerateReward(bgPlayer,OrbsReward);
                                 AtlasROGManager.GenerateBeetleCarapace(bgPlayer);
                                 bgPlayer.Achieve($"{achievementMob}-Credit");
                             }
@@ -91,7 +91,7 @@ namespace DOL.GS {
                         if (groupPlayer.IsWithinRadius(this, WorldMgr.MAX_EXPFORKILL_DISTANCE))
                         {
                             if (groupPlayer.Level < 45) continue;
-                            AtlasROGManager.GenerateOrbAmount(groupPlayer,OrbsReward);
+                            AtlasROGManager.GenerateReward(groupPlayer,OrbsReward);
                             AtlasROGManager.GenerateBeetleCarapace(groupPlayer);
                             groupPlayer.Achieve($"{achievementMob}-Credit");
                         }
@@ -101,7 +101,7 @@ namespace DOL.GS {
                 {
                     if (playerKiller.Level >= 45)
                     {
-                        AtlasROGManager.GenerateOrbAmount(playerKiller,OrbsReward);
+                        AtlasROGManager.GenerateReward(playerKiller,OrbsReward);
                         AtlasROGManager.GenerateBeetleCarapace(playerKiller);
                         playerKiller.Achieve($"{achievementMob}-Credit");;
                     }

--- a/GameServer/gameobjects/GameEpicNPC.cs
+++ b/GameServer/gameobjects/GameEpicNPC.cs
@@ -86,7 +86,7 @@ namespace DOL.GS
 
                                 if (Util.Chance(baseChance + realmLoyalty))
                                 {
-                                    AtlasROGManager.GenerateOrbAmount(bgPlayer, amount);
+                                    AtlasROGManager.GenerateReward(bgPlayer, amount);
                                 }
 
                                 if (Util.ChanceDouble(carapaceChance))
@@ -111,7 +111,7 @@ namespace DOL.GS
 
                             if (Util.Chance(baseChance + realmLoyalty))
                             {
-                                AtlasROGManager.GenerateOrbAmount(groupPlayer, amount);
+                                AtlasROGManager.GenerateReward(groupPlayer, amount);
                             }
                             if (Util.ChanceDouble(carapaceChance))
                             {
@@ -128,7 +128,7 @@ namespace DOL.GS
                     {
                         if (Util.Chance(baseChance + realmLoyalty))
                         {
-                            AtlasROGManager.GenerateOrbAmount(playerKiller, amount);
+                            AtlasROGManager.GenerateReward(playerKiller, amount);
                         }
 
                         if (Util.ChanceDouble(carapaceChance))

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -5884,7 +5884,7 @@ namespace DOL.GS
                     HCFlag = false;
                     HCCompleted = true;
                     Out.SendMessage("You have reached Level 50! Your Hardcore flag has been disabled.", eChatType.CT_Important, eChatLoc.CL_SystemWindow);
-                    AtlasROGManager.GenerateOrbAmount(this, 5000);
+                    AtlasROGManager.GenerateReward(this, 5000);
                 }
                 
                 // Creates a TimeXLevel to track the levelling time to 50

--- a/GameServer/managers/ConquestManager/ConquestManager.cs
+++ b/GameServer/managers/ConquestManager/ConquestManager.cs
@@ -246,7 +246,7 @@ public class ConquestManager
             if (!primaryObjective) awardBase = (int)(awardBase * 0.75);
             int numFlags = ActiveObjective.GetNumFlagsOwnedByRealm(player.Realm);
             player.GainRealmPoints((long)(awardBase + (numFlags * 200)), false);
-            AtlasROGManager.GenerateOrbAmount(player, (int)(awardBase + (numFlags * 200)));
+            AtlasROGManager.GenerateReward(player, (int)(awardBase + (numFlags * 200)));
         }
     }
     

--- a/GameServer/managers/RandomObjectGeneration/AtlasROGManager.cs
+++ b/GameServer/managers/RandomObjectGeneration/AtlasROGManager.cs
@@ -120,6 +120,51 @@ namespace DOL.GS {
                         invitem.Name), eChatType.CT_Loot, eChatLoc.CL_SystemWindow);
             }
         }
+
+        public static void GenerateReward(GameLiving living, int amount)
+        {
+            if (GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvP)
+            {
+                GenerateBPs(living, amount);
+            }
+            else
+            {
+                GenerateOrbAmount(living, amount);
+            }
+        }
+
+        private static void GenerateBPs(GameLiving living, int amount)
+        {
+            if (amount == 0) return; 
+
+            if (living != null && living is GamePlayer)
+            {
+                var player = living as GamePlayer;
+                
+
+                double numCurrentLoyalDays = LoyaltyManager.GetPlayerRealmLoyalty(player) != null ? LoyaltyManager.GetPlayerRealmLoyalty(player).Days : 0;
+
+                if(numCurrentLoyalDays >= 30)
+                {
+                    numCurrentLoyalDays = 30;
+                }
+
+                var loyaltyBonus = ((amount * .2) * (numCurrentLoyalDays / 30));
+                
+                double relicBonus = (amount * (0.025 * RelicMgr.GetRelicCount(player.Realm)));
+
+                var totBPs = amount + Convert.ToInt32(loyaltyBonus) + Convert.ToInt32(relicBonus);
+                
+                player.GainBountyPoints(totBPs, false);
+                
+                if (loyaltyBonus > 0)
+                    player.Out.SendMessage($"You gained an additional {Convert.ToInt32(loyaltyBonus)} BPs due to your realm loyalty!", eChatType.CT_Important, eChatLoc.CL_SystemWindow);
+                if (relicBonus > 0)
+                    player.Out.SendMessage($"You gained an additional {Convert.ToInt32(relicBonus)} BPs due to your realm's relic ownership!", eChatType.CT_Important, eChatLoc.CL_SystemWindow);
+
+            }
+            
+        }
         public static void GenerateOrbAmount(GameLiving living, int amount)
         {
             if (amount == 0) return; 

--- a/GameServer/scripts/AtlasEvents/LaunchRewardNPC.cs
+++ b/GameServer/scripts/AtlasEvents/LaunchRewardNPC.cs
@@ -109,7 +109,7 @@ namespace DOL.GS.Scripts
                                            $"The whole realm of {RealmName(Realm)} thanks you for your help and wish you luck with your adventures! \n \n" +
                                            "Now, don't forget to visit my friend Cruella de Ville, I'm sure she will have more rewards for you.", eChatType.CT_Say, eChatLoc.CL_PopupWindow);
                     
-                    AtlasROGManager.GenerateOrbAmount(player, OrbsReward);
+                    AtlasROGManager.GenerateReward(player, OrbsReward);
                     SetCustomParam(player);
                     return true;
                 default:

--- a/GameServer/scripts/AtlasEvents/ToonTraderNPC.cs
+++ b/GameServer/scripts/AtlasEvents/ToonTraderNPC.cs
@@ -181,7 +181,7 @@ namespace DOL.GS.Scripts
 
                     player.MoveTo(249, 47400, 48686, 25000, 2085);
 
-                    AtlasROGManager.GenerateOrbAmount(player, orbAmount);
+                    AtlasROGManager.GenerateReward(player, orbAmount);
 
                     GameServer.Database.SaveObject(player.Client.Account);
 

--- a/GameServer/scripts/namedmobs/Dodens/JarlOrmarr.cs
+++ b/GameServer/scripts/namedmobs/Dodens/JarlOrmarr.cs
@@ -130,7 +130,7 @@ namespace DOL.GS.Scripts
 			{
 				foreach (GamePlayer groupPlayer in playerKiller.Group.GetPlayersInTheGroup())
 				{
-					AtlasROGManager.GenerateOrbAmount(groupPlayer,OrbsReward);
+					AtlasROGManager.GenerateReward(groupPlayer,OrbsReward);
 				}
 			}
 			base.Die(killer);

--- a/GameServer/scripts/quests/AtlasQuests/BeetleQuests/Albion/PvE Quest/BeetlePvEQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/BeetleQuests/Albion/PvE Quest/BeetlePvEQuestAlb.cs
@@ -606,7 +606,7 @@ namespace DOL.GS.AtlasQuest.Albion
 		{
 			m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 8, 32, Util.Random(50)),
 				"You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 5000);
+			AtlasROGManager.GenerateReward(m_questPlayer, 5000);
 			_grandSummonerKilled = 0;
 			_legionKilled = 0;
 			_dragonKilled = 0;

--- a/GameServer/scripts/quests/AtlasQuests/BeetleQuests/Albion/RvR Quest/BeetleRvRQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/BeetleQuests/Albion/RvR Quest/BeetleRvRQuestAlb.cs
@@ -614,7 +614,7 @@ namespace DOL.GS.AtlasQuest.Albion
 			
 			m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 8, 32, Util.Random(50)),
 				"You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 5000);
+			AtlasROGManager.GenerateReward(m_questPlayer, 5000);
 			_enemiesKilled = 0;
 			_captured = 0;
 			_relicsCaptured = 0;

--- a/GameServer/scripts/quests/AtlasQuests/BeetleQuests/Hibernia/PvE Quest/BeetlePvEQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/BeetleQuests/Hibernia/PvE Quest/BeetlePvEQuestHib.cs
@@ -606,7 +606,7 @@ namespace DOL.GS.AtlasQuest.Hibernia
 		{
 			m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 8, 32, Util.Random(50)),
 				"You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 5000);
+			AtlasROGManager.GenerateReward(m_questPlayer, 5000);
 			_grandSummonerKilled = 0;
 			_legionKilled = 0;
 			_dragonKilled = 0;

--- a/GameServer/scripts/quests/AtlasQuests/BeetleQuests/Hibernia/RvR Quest/BeetleRvRQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/BeetleQuests/Hibernia/RvR Quest/BeetleRvRQuestHib.cs
@@ -614,7 +614,7 @@ namespace DOL.GS.AtlasQuest.Hibernia
 			
 			m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 8, 32, Util.Random(50)),
 				"You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 5000);
+			AtlasROGManager.GenerateReward(m_questPlayer, 5000);
 			_enemiesKilled = 0;
 			_captured = 0;
 			_relicsCaptured = 0;

--- a/GameServer/scripts/quests/AtlasQuests/BeetleQuests/Midgard/PvE Quest/BeetlePvEQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/BeetleQuests/Midgard/PvE Quest/BeetlePvEQuestMid.cs
@@ -607,7 +607,7 @@ namespace DOL.GS.AtlasQuest.Midgard
 		{
 			m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 8, 32, Util.Random(50)),
 				"You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 5000);
+			AtlasROGManager.GenerateReward(m_questPlayer, 5000);
 			_grandSummonerKilled = 0;
 			_legionKilled = 0;
 			_dragonKilled = 0;

--- a/GameServer/scripts/quests/AtlasQuests/BeetleQuests/Midgard/RvR Quest/BeetleRvRQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/BeetleQuests/Midgard/RvR Quest/BeetleRvRQuestMid.cs
@@ -616,7 +616,7 @@ namespace DOL.GS.AtlasQuest.Midgard
 			
 			m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 8, 32, Util.Random(50)),
 				"You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 5000);
+			AtlasROGManager.GenerateReward(m_questPlayer, 5000);
 			_enemiesKilled = 0;
 			_captured = 0;
 			_relicsCaptured = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Frontier/Daily/CaptureKeepQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Frontier/Daily/CaptureKeepQuestAlb.cs
@@ -352,7 +352,7 @@ namespace DOL.GS.DailyQuest.Albion
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,0,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 250);
+			AtlasROGManager.GenerateReward(m_questPlayer, 250);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(5, 11));
 			_isCaptured = 0;
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Frontier/Daily/KillNPCInFrontiersAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Frontier/Daily/KillNPCInFrontiersAlb.cs
@@ -358,7 +358,7 @@ namespace DOL.GS.DailyQuest.Albion
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/2);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 2,50,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 150);
+			AtlasROGManager.GenerateReward(m_questPlayer, 150);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(5, 11));
 			FrontierMobsKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Frontier/Monthly/CaptureRelicQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Frontier/Monthly/CaptureRelicQuestAlb.cs
@@ -361,7 +361,7 @@ namespace DOL.GS.MonthlyQuest.Albion
 			{
 				m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 				m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*8,0,Util.Random(50)), "You receive {0} as a reward.");
-				AtlasROGManager.GenerateOrbAmount(m_questPlayer, 5000);
+				AtlasROGManager.GenerateReward(m_questPlayer, 5000);
 				AtlasROGManager.GenerateBeetleCarapace(m_questPlayer, 2);
 				AtlasROGManager.GenerateJewel(m_questPlayer, 51);
 				_isCaptured = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Frontier/Monthly/FrontiersMonthlyQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Frontier/Monthly/FrontiersMonthlyQuestAlb.cs
@@ -380,7 +380,7 @@ namespace DOL.GS.MonthlyQuest.Albion
 				m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 				m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 8, 32, Util.Random(50)),
 					"You receive {0} as a reward.");
-				AtlasROGManager.GenerateOrbAmount(m_questPlayer, 5000);
+				AtlasROGManager.GenerateReward(m_questPlayer, 5000);
 				AtlasROGManager.GenerateBeetleCarapace(m_questPlayer, 2);
 				AtlasROGManager.GenerateJewel(m_questPlayer, 50);
 				PlayersKilled = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Frontier/Weekly/DFMobKillQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Frontier/Weekly/DFMobKillQuestAlb.cs
@@ -385,7 +385,7 @@ namespace DOL.GS.WeeklyQuest.Albion
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			_mobsKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 		}

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Frontier/Weekly/EpicRvRMobsWeeklyQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Frontier/Weekly/EpicRvRMobsWeeklyQuestAlb.cs
@@ -373,7 +373,7 @@ namespace DOL.GS.WeeklyQuest.Albion
 		{
 			//m_questPlayer.GainExperience(eXPSource.Quest, (m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/10, true);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(10, 11));
 			_evernKilled = 0;
 			_glacierGiantKilled = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Hardcore/HardcoreKillAPlayerAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Hardcore/HardcoreKillAPlayerAlb.cs
@@ -360,7 +360,7 @@ namespace DOL.GS.DailyQuest
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/2);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 250);
+			AtlasROGManager.GenerateReward(m_questPlayer, 250);
 			PlayerKilled = 0;
 			
 			if (reward > 0)

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Hardcore/HardcoreKillNPCInFrontiersAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Hardcore/HardcoreKillNPCInFrontiersAlb.cs
@@ -381,7 +381,7 @@ namespace DOL.GS.DailyQuest
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/2);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 150);
+			AtlasROGManager.GenerateReward(m_questPlayer, 150);
 			FrontierMobsKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Hardcore/HardcoreKillOrangesAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Hardcore/HardcoreKillOrangesAlb.cs
@@ -379,7 +379,7 @@ namespace DOL.GS.DailyQuest
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/2);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 150);
+			AtlasROGManager.GenerateReward(m_questPlayer, 150);
 			OrangeConKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/PvE/Daily/DanaoinKillQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/PvE/Daily/DanaoinKillQuestAlb.cs
@@ -346,7 +346,7 @@ namespace DOL.GS.DailyQuest.Albion
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/10);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,50,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 100);
+			AtlasROGManager.GenerateReward(m_questPlayer, 100);
 			danaoinKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 		}

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/PvE/Daily/SidiMobQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/PvE/Daily/SidiMobQuestAlb.cs
@@ -364,7 +364,7 @@ namespace DOL.GS.DailyQuest.Albion
         {
             m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel) / 5);
             m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level, 0, Util.Random(50)), "You receive {0} as a reward.");
-            AtlasROGManager.GenerateOrbAmount(m_questPlayer, 100);
+            AtlasROGManager.GenerateReward(m_questPlayer, 100);
             _deadSidiMob = 0;
             base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
         }

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/PvE/Daily/TeamBuildingAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/PvE/Daily/TeamBuildingAlb.cs
@@ -406,7 +406,7 @@ namespace DOL.GS.DailyQuest.Albion
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,50,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 300);
+			AtlasROGManager.GenerateReward(m_questPlayer, 300);
 			TeamBuildMobsKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 		}

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/PvE/Monthly/MonthlyEpicPvEQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/PvE/Monthly/MonthlyEpicPvEQuestAlb.cs
@@ -368,7 +368,7 @@ namespace DOL.GS.MonthlyQuest.Albion
 				m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 				m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 8, 32, Util.Random(50)),
 					"You receive {0} as a reward.");
-				AtlasROGManager.GenerateOrbAmount(m_questPlayer, 3000);
+				AtlasROGManager.GenerateReward(m_questPlayer, 3000);
 				AtlasROGManager.GenerateBeetleCarapace(m_questPlayer, 2);
 				AtlasROGManager.GenerateJewel(m_questPlayer, 51);
 				_orylleKilled = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/PvE/Weekly/DragonWeeklyQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/PvE/Weekly/DragonWeeklyQuestAlb.cs
@@ -349,7 +349,7 @@ namespace DOL.GS.WeeklyQuest.Albion
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			DragonKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 		}

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/PvE/Weekly/SidiBossQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/PvE/Weekly/SidiBossQuestAlb.cs
@@ -363,7 +363,7 @@ namespace DOL.GS.WeeklyQuest.Albion
         {
             m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
             m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 5, 0, Util.Random(50)), "You receive {0} as a reward.");
-            AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+            AtlasROGManager.GenerateReward(m_questPlayer, 1500);
             _deadSidiBossMob = 0;
             base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
         }

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/RvR/Daily/EveryLittleBitHelpsQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/RvR/Daily/EveryLittleBitHelpsQuestAlb.cs
@@ -365,7 +365,7 @@ namespace DOL.GS.DailyQuest.Albion
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 250);
+			AtlasROGManager.GenerateReward(m_questPlayer, 250);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(5, 15));
 			_playersKilledHib = 0;
 			_playersKilledMid = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/RvR/Daily/PlayerKillQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/RvR/Daily/PlayerKillQuestAlb.cs
@@ -359,7 +359,7 @@ namespace DOL.GS.DailyQuest.Albion
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 250);
+			AtlasROGManager.GenerateReward(m_questPlayer, 250);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(5, 15));
 			PlayersKilled = 0;
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/RvR/Weekly/DFWeeklyKillQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/RvR/Weekly/DFWeeklyKillQuestAlb.cs
@@ -362,7 +362,7 @@ namespace DOL.GS.WeeklyQuest.Albion
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			EnemiesKilled = 0;
 			
 			if (reward > 0)

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/RvR/Weekly/ForTheRealmQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/RvR/Weekly/ForTheRealmQuestAlb.cs
@@ -365,7 +365,7 @@ namespace DOL.GS.WeeklyQuest.Albion
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(10, 20));
 			_playersKilledHib = 0;
 			_playersKilledMid = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/RvR/Weekly/PlayerKillWeeklyQuestAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/RvR/Weekly/PlayerKillWeeklyQuestAlb.cs
@@ -353,7 +353,7 @@ namespace DOL.GS.WeeklyQuests.Albion
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(10, 20));
 			PlayersKilled = 0;
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Frontier/Daily/CaptureKeepQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Frontier/Daily/CaptureKeepQuestHib.cs
@@ -350,7 +350,7 @@ namespace DOL.GS.DailyQuest.Hibernia
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,0,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 250);
+			AtlasROGManager.GenerateReward(m_questPlayer, 250);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(5, 11));
 			_isCaptured = 0;
 

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Frontier/Daily/KillNPCInFrontiersHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Frontier/Daily/KillNPCInFrontiersHib.cs
@@ -354,7 +354,7 @@ namespace DOL.GS.DailyQuest.Hibernia
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/10);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,50,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 150);
+			AtlasROGManager.GenerateReward(m_questPlayer, 150);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(5, 11));
 			FrontierMobsKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Frontier/Monthly/CaptureRelicQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Frontier/Monthly/CaptureRelicQuestHib.cs
@@ -361,7 +361,7 @@ namespace DOL.GS.MonthlyQuest.Hibernia
 			{
 				m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 				m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*8,0,Util.Random(50)), "You receive {0} as a reward.");
-				AtlasROGManager.GenerateOrbAmount(m_questPlayer, 5000);
+				AtlasROGManager.GenerateReward(m_questPlayer, 5000);
 				AtlasROGManager.GenerateBeetleCarapace(m_questPlayer, 2);
 				AtlasROGManager.GenerateJewel(m_questPlayer, 51);
 				_isCaptured = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Frontier/Monthly/FrontiersMonthlyQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Frontier/Monthly/FrontiersMonthlyQuestHib.cs
@@ -380,7 +380,7 @@ namespace DOL.GS.MonthlyQuest.Hibernia
 				m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 				m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 8, 32, Util.Random(50)),
 					"You receive {0} as a reward.");
-				AtlasROGManager.GenerateOrbAmount(m_questPlayer, 5000);
+				AtlasROGManager.GenerateReward(m_questPlayer, 5000);
 				AtlasROGManager.GenerateBeetleCarapace(m_questPlayer, 2);
 				AtlasROGManager.GenerateJewel(m_questPlayer, 50);
 				PlayersKilled = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Frontier/Weekly/DFMobKillQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Frontier/Weekly/DFMobKillQuestHib.cs
@@ -375,7 +375,7 @@ namespace DOL.GS.WeeklyQuest.Hibernia
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			_mobsKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 		}

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Frontier/Weekly/EpicRvRMobsWeeklyQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Frontier/Weekly/EpicRvRMobsWeeklyQuestHib.cs
@@ -373,7 +373,7 @@ namespace DOL.GS.WeeklyQuest.Hibernia
 		{
 			//m_questPlayer.GainExperience(eXPSource.Quest, (m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/10, true);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(10, 11));
 			_evernKilled = 0;
 			_glacierGiantKilled = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Hardcore/Daily/HardcoreKillAPlayerHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Hardcore/Daily/HardcoreKillAPlayerHib.cs
@@ -366,7 +366,7 @@ namespace DOL.GS.DailyQuest
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/2);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 250);
+			AtlasROGManager.GenerateReward(m_questPlayer, 250);
 			PlayerKilled = 0;
 			
 			if (reward > 0)

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Hardcore/Daily/HardcoreKillNPCInFrontiersHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Hardcore/Daily/HardcoreKillNPCInFrontiersHib.cs
@@ -384,7 +384,7 @@ namespace DOL.GS.DailyQuest
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/2);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 150);
+			AtlasROGManager.GenerateReward(m_questPlayer, 150);
 			FrontierMobsKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Hardcore/Daily/HardcoreKillOrangesHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Hardcore/Daily/HardcoreKillOrangesHib.cs
@@ -382,7 +382,7 @@ namespace DOL.GS.DailyQuest
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/2);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 150);
+			AtlasROGManager.GenerateReward(m_questPlayer, 150);
 			OrangeConKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/PvE/Daily/GallaMobQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/PvE/Daily/GallaMobQuestHib.cs
@@ -366,7 +366,7 @@ namespace DOL.GS.DailyQuest.Hibernia
         {
             m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
             m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level, 0, Util.Random(50)), "You receive {0} as a reward.");
-            AtlasROGManager.GenerateOrbAmount(m_questPlayer, 100);
+            AtlasROGManager.GenerateReward(m_questPlayer, 100);
             _deadGallaMob = 0;
             base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
         }

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/PvE/Daily/OctonidKillQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/PvE/Daily/OctonidKillQuestHib.cs
@@ -349,7 +349,7 @@ namespace DOL.GS.DailyQuest.Hibernia
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/10);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,50,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 100);
+			AtlasROGManager.GenerateReward(m_questPlayer, 100);
 			OctonidKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 		}

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/PvE/Daily/TeamBuildingHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/PvE/Daily/TeamBuildingHib.cs
@@ -411,7 +411,7 @@ namespace DOL.GS.DailyQuest.Hibernia
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,50,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 300);
+			AtlasROGManager.GenerateReward(m_questPlayer, 300);
 			TeamBuildMobsKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 		}

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/PvE/Monthly/MonthlyEpicPvEQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/PvE/Monthly/MonthlyEpicPvEQuestHib.cs
@@ -368,7 +368,7 @@ namespace DOL.GS.MonthlyQuest.Hibernia
 				m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 				m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 8, 32, Util.Random(50)),
 					"You receive {0} as a reward.");
-				AtlasROGManager.GenerateOrbAmount(m_questPlayer, 3000);
+				AtlasROGManager.GenerateReward(m_questPlayer, 3000);
 				AtlasROGManager.GenerateBeetleCarapace(m_questPlayer, 2);
 				AtlasROGManager.GenerateJewel(m_questPlayer, 51);
 				_balorKilled = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/PvE/Weekly/DragonWeeklyQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/PvE/Weekly/DragonWeeklyQuestHib.cs
@@ -349,7 +349,7 @@ namespace DOL.GS.WeeklyQuest.Hibernia
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			DragonKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 		}

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/PvE/Weekly/GalladoriaBossQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/PvE/Weekly/GalladoriaBossQuestHib.cs
@@ -364,7 +364,7 @@ namespace DOL.GS.WeeklyQuest.Hibernia
         {
             m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
             m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 5, 0, Util.Random(50)), "You receive {0} as a reward.");
-            AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+            AtlasROGManager.GenerateReward(m_questPlayer, 1500);
             _deadGallaBossMob = 0;
             base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
         }

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/RvR/Daily/EveryLittleBitHelpsQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/RvR/Daily/EveryLittleBitHelpsQuestHib.cs
@@ -366,7 +366,7 @@ namespace DOL.GS.DailyQuest.Hibernia
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 250);
+			AtlasROGManager.GenerateReward(m_questPlayer, 250);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(5, 15));
 			_playersKilledAlb = 0;
 			_playersKilledMid = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/RvR/Daily/PlayerKillQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/RvR/Daily/PlayerKillQuestHib.cs
@@ -352,7 +352,7 @@ namespace DOL.GS.DailyQuest.Hibernia
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 250);
+			AtlasROGManager.GenerateReward(m_questPlayer, 250);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(5, 15));
 			PlayersKilled = 0;
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/RvR/Weekly/DFWeeklyKillQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/RvR/Weekly/DFWeeklyKillQuestHib.cs
@@ -358,7 +358,7 @@ namespace DOL.GS.WeeklyQuest.Hibernia
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			EnemiesKilled = 0;
 			
 			if (reward > 0)

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/RvR/Weekly/ForTheRealmQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/RvR/Weekly/ForTheRealmQuestHib.cs
@@ -371,7 +371,7 @@ namespace DOL.GS.WeeklyQuest.Hibernia
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(10, 20));
 			_playersKilledAlb = 0;
 			_playersKilledMid = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/RvR/Weekly/PlayerKillWeeklyQuestHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/RvR/Weekly/PlayerKillWeeklyQuestHib.cs
@@ -353,7 +353,7 @@ namespace DOL.GS.WeeklyQuests.Hibernia
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(10, 20));
 			PlayersKilled = 0;
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Frontier/Daily/CaptureKeepQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Frontier/Daily/CaptureKeepQuestMid.cs
@@ -348,7 +348,7 @@ namespace DOL.GS.DailyQuest.Midgard
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,0,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 150);
+			AtlasROGManager.GenerateReward(m_questPlayer, 150);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(5, 11));
 			_isCaptured = 0;
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Frontier/Daily/KillNPCInFrontiersMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Frontier/Daily/KillNPCInFrontiersMid.cs
@@ -358,7 +358,7 @@ namespace DOL.GS.DailyQuest.Hibernia
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/10);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,50,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 150);
+			AtlasROGManager.GenerateReward(m_questPlayer, 150);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(5, 11));
 			FrontierMobsKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Frontier/Monthly/CaptureRelicQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Frontier/Monthly/CaptureRelicQuestMid.cs
@@ -361,7 +361,7 @@ namespace DOL.GS.MonthlyQuest.Midgard
 			{
 				m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 				m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*8,0,Util.Random(50)), "You receive {0} as a reward.");
-				AtlasROGManager.GenerateOrbAmount(m_questPlayer, 5000);
+				AtlasROGManager.GenerateReward(m_questPlayer, 5000);
 				AtlasROGManager.GenerateBeetleCarapace(m_questPlayer, 2);
 				AtlasROGManager.GenerateJewel(m_questPlayer, 51);
 				_isCaptured = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Frontier/Monthly/FrontiersMonthlyQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Frontier/Monthly/FrontiersMonthlyQuestMid.cs
@@ -377,7 +377,7 @@ namespace DOL.GS.MonthlyQuest.Midgard
 				m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 				m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 8, 32, Util.Random(50)),
 					"You receive {0} as a reward.");
-				AtlasROGManager.GenerateOrbAmount(m_questPlayer, 5000);
+				AtlasROGManager.GenerateReward(m_questPlayer, 5000);
 				AtlasROGManager.GenerateBeetleCarapace(m_questPlayer, 2);
 				AtlasROGManager.GenerateJewel(m_questPlayer, 51);
 				PlayersKilled = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Frontier/Weekly/DFMobKillQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Frontier/Weekly/DFMobKillQuestMid.cs
@@ -378,7 +378,7 @@ namespace DOL.GS.WeeklyQuest.Midgard
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			_mobsKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 		}

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Frontier/Weekly/EpicRvRMobsWeeklyQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Frontier/Weekly/EpicRvRMobsWeeklyQuestMid.cs
@@ -373,7 +373,7 @@ namespace DOL.GS.WeeklyQuest.Midgard
 		{
 			//m_questPlayer.GainExperience(eXPSource.Quest, (m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/10, true);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(10, 11));
 			_evernKilled = 0;
 			_glacierGiantKilled = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Hardcore/HardcoreKillAPlayerMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Hardcore/HardcoreKillAPlayerMid.cs
@@ -360,7 +360,7 @@ namespace DOL.GS.DailyQuest
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/2);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 250);
+			AtlasROGManager.GenerateReward(m_questPlayer, 250);
 			PlayerKilled = 0;
 			
 			if (reward > 0)

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Hardcore/HardcoreKillNPCInFrontiersMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Hardcore/HardcoreKillNPCInFrontiersMid.cs
@@ -383,7 +383,7 @@ namespace DOL.GS.DailyQuest
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/2);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 150);
+			AtlasROGManager.GenerateReward(m_questPlayer, 150);
 			FrontierMobsKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Hardcore/HardcoreKillOrangesMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Hardcore/HardcoreKillOrangesMid.cs
@@ -380,7 +380,7 @@ namespace DOL.GS.DailyQuest
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/2);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 150);
+			AtlasROGManager.GenerateReward(m_questPlayer, 150);
 			OrangeConKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/PvE/Daily/MegalocerosKillQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/PvE/Daily/MegalocerosKillQuestMid.cs
@@ -350,7 +350,7 @@ namespace DOL.GS.DailyQuest.Midgard
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/10);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,50,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 100);
+			AtlasROGManager.GenerateReward(m_questPlayer, 100);
 			megalocerosKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 		}

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/PvE/Daily/TeamBuildingMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/PvE/Daily/TeamBuildingMid.cs
@@ -407,7 +407,7 @@ namespace DOL.GS.DailyQuest.Midgard
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,50,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 300);
+			AtlasROGManager.GenerateReward(m_questPlayer, 300);
 			TeamBuildMobsKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 		}

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/PvE/Daily/TuscarianMobQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/PvE/Daily/TuscarianMobQuestMid.cs
@@ -370,7 +370,7 @@ namespace DOL.GS.DailyQuest.Midgard
         {
             m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
             m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level, 0, Util.Random(50)), "You receive {0} as a reward.");
-            AtlasROGManager.GenerateOrbAmount(m_questPlayer, 100);
+            AtlasROGManager.GenerateReward(m_questPlayer, 100);
             _deadTuscaMob = 0;
             base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
         }

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/PvE/Monthly/MonthlyEpicPvEQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/PvE/Monthly/MonthlyEpicPvEQuestMid.cs
@@ -370,7 +370,7 @@ namespace DOL.GS.MonthlyQuest.Midgard
 				m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 				m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 8, 32, Util.Random(50)),
 					"You receive {0} as a reward.");
-				AtlasROGManager.GenerateOrbAmount(m_questPlayer, 3000);
+				AtlasROGManager.GenerateReward(m_questPlayer, 3000);
 				AtlasROGManager.GenerateBeetleCarapace(m_questPlayer, 2);
 				AtlasROGManager.GenerateJewel(m_questPlayer, 51);
 				_iarnvidiurKilled = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/PvE/Weekly/DragonWeeklyQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/PvE/Weekly/DragonWeeklyQuestMid.cs
@@ -347,7 +347,7 @@ namespace DOL.GS.WeeklyQuest.Midgard
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			DragonKilled = 0;
 			base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
 		}

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/PvE/Weekly/TuscarianBossQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/PvE/Weekly/TuscarianBossQuestMid.cs
@@ -367,7 +367,7 @@ namespace DOL.GS.WeeklyQuest.Midgard
         {
             m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
             m_questPlayer.AddMoney(Money.GetMoney(0, 0, m_questPlayer.Level * 5, 0, Util.Random(50)), "You receive {0} as a reward.");
-            AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+            AtlasROGManager.GenerateReward(m_questPlayer, 1500);
             _deadTuscaBossMob = 0;
             base.FinishQuest(); //Defined in Quest, changes the state, stores in DB etc ...
         }

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/RvR/Daily/EveryLittleBitHelpsQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/RvR/Daily/EveryLittleBitHelpsQuestMid.cs
@@ -364,7 +364,7 @@ namespace DOL.GS.DailyQuest.Midgard
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 250);
+			AtlasROGManager.GenerateReward(m_questPlayer, 250);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(5, 15));
 			_playersKilledHib = 0;
 			_playersKilledAlb = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/RvR/Daily/PlayerKillQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/RvR/Daily/PlayerKillQuestMid.cs
@@ -351,7 +351,7 @@ namespace DOL.GS.DailyQuest.Hibernia
 			
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 250);
+			AtlasROGManager.GenerateReward(m_questPlayer, 250);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(5, 15));
 			PlayersKilled = 0;
 			

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/RvR/Weekly/DFWeeklyKillQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/RvR/Weekly/DFWeeklyKillQuestMid.cs
@@ -357,7 +357,7 @@ namespace DOL.GS.WeeklyQuest.Midgard
 			
 			m_questPlayer.ForceGainExperience(m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			EnemiesKilled = 0;
 			
 			if (reward > 0)

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/RvR/Weekly/ForTheRealmQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/RvR/Weekly/ForTheRealmQuestMid.cs
@@ -364,7 +364,7 @@ namespace DOL.GS.WeeklyQuest.Midgard
 			
 			m_questPlayer.ForceGainExperience( (m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel));
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(10, 20));
 			_playersKilledHib = 0;
 			_playersKilledAlb = 0;

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/RvR/Weekly/PlayerKillWeeklyQuestMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/RvR/Weekly/PlayerKillWeeklyQuestMid.cs
@@ -353,7 +353,7 @@ namespace DOL.GS.WeeklyQuests.Midgard
 			
 			m_questPlayer.ForceGainExperience( (m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level * 5,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 1500);
+			AtlasROGManager.GenerateReward(m_questPlayer, 1500);
 			AtlasROGManager.GenerateJewel(m_questPlayer, (byte)(m_questPlayer.Level + 1), m_questPlayer.Level + Util.Random(10, 20));
 			PlayersKilled = 0;
 			

--- a/GameServer/scripts/quests/Launch Event/LaunchQuestAlb.cs
+++ b/GameServer/scripts/quests/Launch Event/LaunchQuestAlb.cs
@@ -427,7 +427,7 @@ namespace DOL.GS
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 15000);
+			AtlasROGManager.GenerateReward(m_questPlayer, 15000);
 			PlayersKilled = 0;
 			KeepsTaken = 0;
 			RelicsTaken = 0;

--- a/GameServer/scripts/quests/Launch Event/LaunchQuestHib.cs
+++ b/GameServer/scripts/quests/Launch Event/LaunchQuestHib.cs
@@ -426,7 +426,7 @@ namespace DOL.GS
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 15000);
+			AtlasROGManager.GenerateReward(m_questPlayer, 15000);
 			PlayersKilled = 0;
 			KeepsTaken = 0;
 			RelicsTaken = 0;

--- a/GameServer/scripts/quests/Launch Event/LaunchQuestMid.cs
+++ b/GameServer/scripts/quests/Launch Event/LaunchQuestMid.cs
@@ -425,7 +425,7 @@ namespace DOL.GS
 		{
 			m_questPlayer.ForceGainExperience((m_questPlayer.ExperienceForNextLevel - m_questPlayer.ExperienceForCurrentLevel)/5);
 			m_questPlayer.AddMoney(Money.GetMoney(0,0,m_questPlayer.Level*2,32,Util.Random(50)), "You receive {0} as a reward.");
-			AtlasROGManager.GenerateOrbAmount(m_questPlayer, 15000);
+			AtlasROGManager.GenerateReward(m_questPlayer, 15000);
 			PlayersKilled = 0;
 			KeepsTaken = 0;
 			RelicsTaken = 0;

--- a/GameServer/serverrules/AbstractServerRules.cs
+++ b/GameServer/serverrules/AbstractServerRules.cs
@@ -1235,7 +1235,7 @@ namespace DOL.GS.ServerRules
 						max *= 5;
 					}
 					//Console.WriteLine($"min {min} max {max}");
-					AtlasROGManager.GenerateOrbAmount(living as GameLiving, Util.Random(min, max));
+					AtlasROGManager.GenerateReward(living as GameLiving, Util.Random(min, max));
 				}
 					
 			});
@@ -2175,7 +2175,11 @@ namespace DOL.GS.ServerRules
             foreach (var player in playersToAward)
             {
                 if (player.Level < 35 || player.GetDistanceTo(killedPlayer) > WorldMgr.MAX_EXPFORKILL_DISTANCE || player.GetConLevel(killedPlayer) <= -3) continue;
-                AtlasROGManager.GenerateOrbAmount(player, Util.Random(50, 150));
+                
+                if (GameServer.Instance.Configuration.ServerType != eGameServerType.GST_PvP)
+                {
+	                AtlasROGManager.GenerateOrbAmount(player, Util.Random(50, 150));
+                }
 
                 int bonusRegion = 0;
                 switch (ZoneBonusRotator.GetCurrentBonusRealm())


### PR DESCRIPTION
This will switch all usages of "GenerateOrbsAmount" with the generic method "GenerateReward".
The only exception is on PlayerKill as BPs are naturally generated in that case.